### PR TITLE
fix(vita): resolve server hostnames without stalling on DNS (+ release v0.1.11)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -206,10 +206,17 @@ jobs:
     - name: Update dependencies
       env:
         BASE_URL: https://github.com/dragonflylee/switchfin/releases/download/vita-packages
+        # curl is rebuilt with ENABLE_THREADED_RESOLVER=ON (scripts/vita/curl) and
+        # hosted on this fork's own vita-packages release: the app resolves server
+        # hostnames from background threads, where the synchronous resolver cannot
+        # honor DNS timeouts, so a slow lookup stalls forever. The other packages
+        # stay on the upstream (known-good) release.
+        CURL_URL: https://github.com/thcolin/pleNx/releases/download/vita-packages
       run: |
-        for pkg in mbedtls-3.6.5-1 curl-8.16.0-2 ffmpeg-n6.0-3 mpv-0.36.0-3; do
+        for pkg in mbedtls-3.6.5-1 ffmpeg-n6.0-3 mpv-0.36.0-3; do
           wget $BASE_URL/${pkg}-arm.tar.xz
         done
+        wget $CURL_URL/curl-8.16.0-3-arm.tar.xz
         apk add ninja
         vdpm $PWD/*-arm.tar.xz
         git config --system --add safe.directory $GITHUB_WORKSPACE

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -124,7 +124,7 @@ jobs:
     - name: Update dependencies
       run: |
         dkp-pacman --noconfirm -U $BASE_URL/hacBrewPack-3.05-1-x86_64.pkg.tar.zst
-        for pkg in mbedtls-3.6.5-1 libssh2-1.11.1-1 dav1d-1.5.3-1 curl-8.16.0-2 ffmpeg-7.1.4-5 libmpv${{ matrix.shuffix }}-0.36.0-5 nspmini-main-1; do
+        for pkg in mbedtls-3.6.5-1 libssh2-1.11.1-1 dav1d-1.5.3-1 curl-8.16.0-2 ffmpeg-7.1.5-5 libmpv${{ matrix.shuffix }}-0.36.0-5 nspmini-main-1; do
           dkp-pacman --noconfirm -U $BASE_URL/switch-${pkg}-any.pkg.tar.zst
         done
         git config --system --add safe.directory $GITHUB_WORKSPACE
@@ -169,7 +169,7 @@ jobs:
         git -C library/borealis apply --verbose ../../scripts/patches/borealis-fixes.patch
     - name: Update dependencies
       run: |
-        for pkg in musl-1.5-3 mbedtls-2.28.10-2 sdl2-2.0.18-19 libcurl-7.80.0-5 dav1d-1.5.3-1 ffmpeg-7.1.4-3 libmpv-0.36.0-2; do
+        for pkg in musl-1.5-3 mbedtls-2.28.10-2 sdl2-2.0.18-19 libcurl-7.80.0-5 dav1d-1.5.3-1 ffmpeg-7.1.5-3 libmpv-0.36.0-2; do
           pacman --noconfirm -U $BASE_URL/ps4-openorbis-${pkg}-any.pkg.tar.gz
         done
         git config --system --add safe.directory $GITHUB_WORKSPACE

--- a/.github/workflows/vita-packages.yaml
+++ b/.github/workflows/vita-packages.yaml
@@ -1,6 +1,7 @@
 name: vita-packages
 
 on:
+  workflow_dispatch:
   push:
     tags: [ vita-packages ]
     branches: [ gxm, mpv ]

--- a/.github/workflows/vita-packages.yaml
+++ b/.github/workflows/vita-packages.yaml
@@ -20,21 +20,20 @@ jobs:
     - name: Install dependency
       run: |
         apk add ninja meson tar patch
-    - name: Build packages
+    - name: Build curl
       run: |
+        # Only curl is customized in this fork (ENABLE_THREADED_RESOLVER=ON, see
+        # scripts/vita/curl); the other Vita deps stay on the upstream
+        # vita-packages release. curl links mbedtls + zlib at build time — zlib
+        # ships with vitasdk, so install just the upstream mbedtls package, then
+        # build curl as an unprivileged user (vita-makepkg refuses to run as root).
+        wget https://github.com/dragonflylee/switchfin/releases/download/vita-packages/mbedtls-3.6.5-1-arm.tar.xz
+        vdpm mbedtls-3.6.5-1-arm.tar.xz
+
         adduser --gecos '' --home ${GITHUB_WORKSPACE}/scripts/vita --disabled-password builder
         echo 'builder ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/builder
         chown -R builder:builder scripts/vita
 
-        su - builder -c "cd mbedtls && vita-makepkg"
-        vdpm $PWD/scripts/vita/mbedtls/*-arm.tar.xz
-        touch /tmp/vdpm_install_mbedtls
-
-        su - builder -c "cd ffmpeg && vita-makepkg"
-        vdpm $PWD/scripts/vita/ffmpeg/*-arm.tar.xz
-        touch /tmp/vdpm_install_ffmpeg
-
-        su - builder -c "cd mpv && vita-makepkg"
         su - builder -c "cd curl && vita-makepkg"
 
     - name: Upload packages
@@ -43,6 +42,9 @@ jobs:
         name: vita-packages
         tag_name: vita-packages
         prerelease: true
-        files: scripts/vita/*/*-arm.tar.xz
+        files: scripts/vita/curl/*-arm.tar.xz
         body: |
+          curl rebuilt with `ENABLE_THREADED_RESOLVER=ON` so the PS Vita can
+          apply DNS timeouts (async resolver) instead of stalling on hostnames.
+
           ![download](https://img.shields.io/github/downloads/${{ github.repository }}/vita-packages/total?label=Downloads)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ prepared with [git-cliff](https://git-cliff.org/) from conventional commits
 hand. For the history of the upstream project this fork is based on, see the
 [Switchfin changelog](https://github.com/dragonflylee/switchfin/blob/dev/CHANGELOG.md).
 
+## [0.1.11] - 2026-07-03
+
+### Fixes
+
+- **PS Vita: servers reached by a hostname no longer stall with an endless
+  "timeout reached".** libcurl was built with the synchronous name resolver, so
+  a DNS lookup issued from a background thread could not be bounded by any
+  timeout — the synchronous resolver can only abort a slow `getaddrinfo()` via
+  `SIGALRM`, which libcurl arms on the main thread alone. A slow-to-resolve
+  hostname (e.g. a duckdns address) therefore hung every request indefinitely,
+  and raising the request-timeout setting had no effect; only a raw LAN IP,
+  which skips name resolution, worked. curl is now built with the threaded
+  resolver so lookups run in a worker thread the timeout can abandon, and
+  `CURLOPT_NOSIGNAL` keeps libcurl off signals on its background threads.
+
 ## [0.1.10] - 2026-06-15
 
 ### Fixes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ include(${BOREALIS_LIBRARY}/cmake/toolchain.cmake)
 project(pleNx)
 set(VERSION_MAJOR "0")
 set(VERSION_MINOR "1")
-set(VERSION_ALTER "10")
+set(VERSION_ALTER "11")
 # 0420 1312: title ID specific to pleNx — the old one (inherited from
 # Switchfin) let the HOME menu serve the "Switchlex" name/icon from its cache
 # even after reinstalling; a fresh ID starts from scratch. Uniqueness verified
@@ -64,7 +64,7 @@ set(PROJECT_AUTHOR "thcolin")
 set(PACKAGE_NAME "fun.thcolin.plenx")
 set(VITA_TITLEID "PLENX0000")
 set(PSN_TITLE_ID "PLNX00000")
-set(VITA_VERSION "00.18")
+set(VITA_VERSION "00.19")
 set(PROJECT_ICON ${CMAKE_CURRENT_SOURCE_DIR}/resources/icon/icon.jpg)
 set(PROJECT_RESOURCES ${CMAKE_CURRENT_SOURCE_DIR}/resources)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")

--- a/app/src/api/http.cpp
+++ b/app/src/api/http.cpp
@@ -120,6 +120,13 @@ HTTP::HTTP() : chunk(nullptr) {
     curl_easy_setopt(this->easy, CURLOPT_VERBOSE, 0L);
     curl_easy_setopt(this->easy, CURLOPT_SSL_VERIFYPEER, 0L);
     curl_easy_setopt(this->easy, CURLOPT_SSL_VERIFYHOST, 0L);
+    // Every request runs from a background thread (ThreadPool / brls::async), so
+    // libcurl must never reach for SIGALRM to time out a name resolve — signals
+    // only work on the main thread and are unsafe multi-threaded (curl docs:
+    // "libcurl cannot function properly multi-threaded unless CURLOPT_NOSIGNAL
+    // is set"). With NOSIGNAL, DNS timeouts rely solely on the async (threaded)
+    // resolver, which is why the Vita curl build must enable it.
+    curl_easy_setopt(this->easy, CURLOPT_NOSIGNAL, 1L);
 #if LIBCURL_VERSION_NUM >= 0x071900 && !defined(__PS4__)
     curl_easy_setopt(this->easy, CURLOPT_TCP_KEEPALIVE, 1L);
 #endif

--- a/scripts/vita/curl/VITABUILD
+++ b/scripts/vita/curl/VITABUILD
@@ -1,6 +1,6 @@
 pkgname=curl
 pkgver=8.16.0
-pkgrel=2
+pkgrel=3
 url="https://curl.se/"
 source=("https://curl.haxx.se/download/curl-${pkgver}.tar.xz")
 sha256sums=('40c8cddbcb6cc6251c03dea423a472a6cea4037be654ba5cf5dec6eb2d22ff1d')
@@ -9,6 +9,16 @@ depends=('mbedtls' 'zlib')
 build() {
   cd curl-${pkgver}
 
+  # ENABLE_THREADED_RESOLVER=ON is required, not optional, on the Vita: the app
+  # runs every request from a background pthread (ThreadPool, __PSV__), and the
+  # synchronous resolver can only abort a slow/hung getaddrinfo via SIGALRM,
+  # which libcurl uses on the main thread only. Without an async resolver a slow
+  # DNS lookup blocks past ANY CURLOPT_*TIMEOUT (curl's own docs: "timeouts
+  # cannot be honored during DNS lookups ... work around by building with c-ares
+  # or threaded-resolver"), so hostname servers stall forever while a raw LAN IP
+  # (no getaddrinfo) works — the exact symptom users hit. The threaded resolver
+  # runs getaddrinfo in a worker thread that the timeout can abandon; c-ares is
+  # unusable here (no /etc/resolv.conf on the Vita, unlike sceNet's getaddrinfo).
   cmake -B build -DCMAKE_TOOLCHAIN_FILE=$VITASDK/share/vita.toolchain.cmake \
     -DCMAKE_INSTALL_PREFIX=$prefix \
     -DCMAKE_BUILD_TYPE=Release \
@@ -23,7 +33,7 @@ build() {
     -DCURL_USE_MBEDTLS=ON \
     -DCURL_DISABLE_PROGRESS_METER=ON \
     -DENABLE_IPV6=OFF \
-    -DENABLE_THREADED_RESOLVER=OFF \
+    -DENABLE_THREADED_RESOLVER=ON \
     -DUSE_NGHTTP2=OFF \
     -DUSE_LIBIDN2=OFF \
     -DCURL_BROTLI=OFF \

--- a/site/404.html
+++ b/site/404.html
@@ -90,7 +90,7 @@
     <p class="footer-legal">
       pleNx is a third-party project, not affiliated with or endorsed by Plex, Inc.
       Nintendo Switch is a trademark of Nintendo. ·
-      <span data-version>v0.1.10</span> · <a href="https://github.com/thcolin/pleNx/blob/dev/CHANGELOG.md">Changelog</a>
+      <span data-version>v0.1.11</span> · <a href="https://github.com/thcolin/pleNx/blob/dev/CHANGELOG.md">Changelog</a>
     </p>
   </footer>
 

--- a/site/guide.html
+++ b/site/guide.html
@@ -233,7 +233,7 @@
     <p class="footer-legal">
       pleNx is a third-party project, not affiliated with or endorsed by Plex, Inc.
       Nintendo Switch is a trademark of Nintendo. ·
-      <span data-version>v0.1.10</span> · <a href="https://github.com/thcolin/pleNx/blob/dev/CHANGELOG.md">Changelog</a>
+      <span data-version>v0.1.11</span> · <a href="https://github.com/thcolin/pleNx/blob/dev/CHANGELOG.md">Changelog</a>
     </p>
   </footer>
 

--- a/site/index.html
+++ b/site/index.html
@@ -52,7 +52,7 @@
         </div>
         <aside class="hero-spec reveal" style="--i:2" aria-label="At a glance">
           <div class="spec-strong">Third-party Plex client</div>
-          <div><a href="https://github.com/thcolin/pleNx/releases/latest">Ver. <span data-version>v0.1.10</span> — out now</a></div>
+          <div><a href="https://github.com/thcolin/pleNx/releases/latest">Ver. <span data-version>v0.1.11</span> — out now</a></div>
           <div>Free &amp; open source</div>
           <div class="spec-muted">Not affiliated with Plex, Inc.</div>
         </aside>
@@ -321,7 +321,7 @@
     <p class="footer-legal">
       pleNx is a third-party project, not affiliated with or endorsed by Plex, Inc.
       Nintendo Switch is a trademark of Nintendo. ·
-      <span data-version>v0.1.10</span> · <a href="https://github.com/thcolin/pleNx/blob/dev/CHANGELOG.md">Changelog</a>
+      <span data-version>v0.1.11</span> · <a href="https://github.com/thcolin/pleNx/blob/dev/CHANGELOG.md">Changelog</a>
     </p>
   </footer>
 


### PR DESCRIPTION
## Problème

Sur PS Vita, l'app « prend une éternité à charger et affiche constamment *timeout reached* », même avec le timeout réglé au maximum. Seul contournement trouvé par les utilisateurs : **utiliser l'IP locale plutôt qu'un hostname** (ex. duckdns).

## Cause racine (vérifiée)

libcurl pour la Vita est compilé avec le **résolveur de noms synchrone** (`ENABLE_THREADED_RESOLVER=OFF`, sans c-ares). Or toutes les requêtes tournent sur un **worker `pthread`** en tâche de fond (`ThreadPool`, `__PSV__`). Le résolveur synchrone ne peut interrompre un `getaddrinfo()` lent que via **SIGALRM**, que libcurl n'arme que sur le thread principal.

→ Un DNS lent (ou momentanément injoignable) **bloque au-delà de n'importe quel `CURLOPT_*TIMEOUT`** ; augmenter le réglage n'y change rien. Une IP brute saute `getaddrinfo` → d'où « use your local IP ».

Doc curl (`libcurl-thread`) : *« timeouts cannot be honored during DNS lookups — work around by building libcurl with c-ares or threaded-resolver support »* et *« libcurl cannot function properly multi-threaded unless CURLOPT_NOSIGNAL is set »*.

## Correctif

- **`scripts/vita/curl`** : `ENABLE_THREADED_RESOLVER=ON` (`pkgrel` → 3).
- **`app/src/api/http.cpp`** : `CURLOPT_NOSIGNAL`.
- **`build.yaml`** : récupère `curl-8.16.0-3` depuis la release `vita-packages` de ce fork (déjà publié).
- **`vita-packages.yaml`** : ne bâtit que curl + `workflow_dispatch` (rebuild à la demande).
- **`build.yaml`** : bump `ffmpeg` Switch/PS4 `7.1.4`→`7.1.5` — l'upstream a supprimé le `7.1.4`, ce qui cassait `build-nx`/`build-ps4` sur `dev` depuis le 30/06 (sans rapport avec ce fix, mais bloquait `upload-release`).
- **release v0.1.11** : bumps CMakeLists (+ VITA_VERSION 00.19), CHANGELOG, site.

## Vérification empirique (curl 8.16.0, flags Vita exacts, thread de fond, résolveur simulé 8 s)

| Build | AsynchDNS | Timeout | Temps réel | Verdict |
|-------|-----------|---------|------------|---------|
| `THREADED_RESOLVER=OFF` (Vita actuel) | NO | 2000 ms | **8027 ms** | ❌ ignoré pendant le DNS |
| `THREADED_RESOLVER=ON` (fix) | YES | 2000 ms | **2004 ms** | ✅ honoré |

## Go-live (le paquet curl-8.16.0-3 est déjà publié)

1. **Merge** cette PR dans `dev`.
2. **Tag `v0.1.11`** sur `dev` + push → build multi-plateforme → publication (updater in-app).

⚠️ Fix non testé sur vraie Vita (mécanisme prouvé sur host uniquement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)