### PR TITLE
fix(win32): derive .rc metadata from CMake vars (#5)

### DIFF
--- a/app/platform/win32/app.rc.in
+++ b/app/platform/win32/app.rc.in
@@ -16,9 +16,9 @@ BEGIN
     BEGIN
         BLOCK "040904B0"
         BEGIN
-            VALUE "FileDescription", "pleNx for Windows"
-            VALUE "LegalCopyright", "dragonflyee (C) Copyright 2026"
-            VALUE "OriginalFilename", "pleNx.exe"
+            VALUE "FileDescription", "${PROJECT_NAME} for Windows"
+            VALUE "LegalCopyright", "${PROJECT_AUTHOR} (C) Copyright 2026"
+            VALUE "OriginalFilename", "${PROJECT_NAME}.exe"
             VALUE "ProductVersion", "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_ALTER}.${VERSION_BUILD}"
         END
     END


### PR DESCRIPTION
## Contexte

L'issue #5 (ouverte par **dragonflylee**, auteur upstream de switchfin) demandait de dériver les métadonnées du resource file Windows des variables CMake plutôt que de les coder en dur. Corrigée en amont, mais jamais reprise dans ce fork.

## Changement

`app/platform/win32/app.rc.in` — remplacement des valeurs en dur par les variables déjà substituées via `configure_file` (CMakeLists:104) :

- `FileDescription` : `pleNx for Windows` → `${PROJECT_NAME} for Windows`
- `LegalCopyright` : `dragonflyee (C) Copyright 2026` → `${PROJECT_AUTHOR} (C) Copyright 2026`
- `OriginalFilename` : `pleNx.exe` → `${PROJECT_NAME}.exe`

Résolution à la compilation : `${PROJECT_NAME}` → `pleNx`, `${PROJECT_AUTHOR}` → `thcolin`.

Au-delà du DRY, ça corrige surtout le `LegalCopyright` qui embarquait le nom de l'auteur upstream (« dragonflyee », avec en plus une coquille) dans les métadonnées du binaire Windows au lieu de `thcolin`.

Cohérent avec le reste du CMakeLists qui utilise déjà ces variables (ex. copyright macOS, ligne 259).

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)