### PR TITLE
fix(remote_view): play() name param + title/profile fixes (supersedes #8)

### DIFF
--- a/app/include/tab/remote_view.hpp
+++ b/app/include/tab/remote_view.hpp
@@ -25,7 +25,7 @@ public:
 
     void dismiss(std::function<void(void)> cb = [] {}) override;
 
-    static void play(const std::string& path, const std::string& name = "");
+    static void play(const std::string& path, const std::string& name = "", const std::string& method = "");
 
 protected:
     void setContent(RecyclingGrid* view);

--- a/app/include/tab/remote_view.hpp
+++ b/app/include/tab/remote_view.hpp
@@ -25,7 +25,7 @@ public:
 
     void dismiss(std::function<void(void)> cb = [] {}) override;
 
-    static void play(const std::string& path);
+    static void play(const std::string& path, const std::string& name = "");
 
 protected:
     void setContent(RecyclingGrid* view);

--- a/app/src/tab/download_tab.cpp
+++ b/app/src/tab/download_tab.cpp
@@ -1,11 +1,11 @@
 #include "tab/download_tab.hpp"
+#include "tab/remote_view.hpp"
 #include "view/recycling_grid.hpp"
 #include "view/video_view.hpp"
 #include "view/mpv_core.hpp"
 #include "view/video_profile.hpp"
 #include "view/player_setting.hpp"
 #include "view/presenter.hpp"
-#include "view/auto_tab_frame.hpp"
 #include "utils/config.hpp"
 #include "utils/dialog.hpp"
 #include "utils/misc.hpp"
@@ -242,55 +242,17 @@ public:
 
         if (item.status == DownloadStatus::Completed) {
             std::string path = dm.getLocalPath(item.itemId);
-            if (!path.empty()) {
-                VideoView* view = new VideoView();
-                float width = brls::Application::contentWidth;
-                float height = brls::Application::contentHeight;
-                view->setDimensions(width, height);
-                view->setWidthPercentage(100);
-                view->setHeightPercentage(100);
-                view->setTitie(item.name);
-                view->hideVideoQuality();
-                // local playback: embedded tracks only (no Plex Media)
-                view->registerVideoSubtitle([](...) {
-                    PlayerSetting::showSubtitleMenu(nullptr);
-                    return true;
-                });
-                view->registerVideoAudio([](...) {
-                    PlayerSetting::showAudioMenu(nullptr);
-                    return true;
-                });
+            if (path.empty()) return;
 
-                auto* profile = view->getProfile();
-                auto& mpv = MPVCore::instance();
-                auto subId = std::make_shared<MPVEvent::Subscription>();
-                auto unsub = std::make_shared<std::atomic_bool>(false);
-                *subId = mpv.getEvent()->subscribe([profile, subId, unsub](MpvEventEnum event) {
-                    if (unsub->load()) return;
-                    if (event == MpvEventEnum::MPV_RESUME) {
-                        profile->init("Local");
-                    } else if (event == MpvEventEnum::MPV_STOP || event == MpvEventEnum::END_OF_FILE ||
-                               event == MpvEventEnum::MPV_FILE_ERROR) {
-                        unsub->store(true);
-                        auto id = *subId;
-                        brls::sync([id]() {
-                            MPVCore::instance().getEvent()->unsubscribe(id);
-                        });
-                    }
-                });
-
-                view->getPlayEvent()->subscribe([](int) { return VideoView::close(true); });
-                view->getSettingEvent()->subscribe([]() {
-                    brls::Application::pushActivity(new brls::Activity(new PlayerSetting()));
-                });
-
-                brls::Box* container = new brls::Box();
-                container->setDimensions(width, height);
-                container->addView(view);
-                brls::Application::pushActivity(new brls::Activity(container), brls::TransitionAnimation::NONE);
-
-                MPVCore::instance().setUrl(path);
+            std::string detail;
+            if (!item.seriesName.empty()) {
+                detail = fmt::format("{} - S{}E{}", item.seriesName, item.seasonIndex, item.episodeIndex);
+            } else if (item.productionYear > 0) {
+                detail = fmt::format("{} ({})", item.name, item.productionYear);
+            } else {
+                detail = item.name;
             }
+            RemoteView::play(path, detail);
         } else if (item.status == DownloadStatus::Downloading) {
             std::string id = item.itemId;
             Dialog::cancelable("main/download/confirm_cancel"_i18n, [id]() {

--- a/app/src/tab/download_tab.cpp
+++ b/app/src/tab/download_tab.cpp
@@ -252,7 +252,7 @@ public:
             } else {
                 detail = item.name;
             }
-            RemoteView::play(path, detail);
+            RemoteView::play(path, detail, "Local");
         } else if (item.status == DownloadStatus::Downloading) {
             std::string id = item.itemId;
             Dialog::cancelable("main/download/confirm_cancel"_i18n, [id]() {

--- a/app/src/tab/remote_view.cpp
+++ b/app/src/tab/remote_view.cpp
@@ -40,6 +40,8 @@ public:
 
         if (item.type == remote::EntryType::PLAYLIST) {
             view->hideVideoProgressSlider();
+        } else if (item.name.size() > 0) {
+            titles.push_back(item.name);
         }
 
         auto& mpv = MPVCore::instance();
@@ -467,8 +469,8 @@ RecyclingGrid* RemoteView::newRecycler() {
     return view;
 }
 
-void RemoteView::play(const std::string& path) {
-    RemotePlayer* view = new RemotePlayer({remote::EntryType::VIDEO, path});
+void RemoteView::play(const std::string& path, const std::string& name) {
+    RemotePlayer* view = new RemotePlayer({remote::EntryType::VIDEO, name, path});
     brls::Application::pushActivity(new brls::Activity(view), brls::TransitionAnimation::NONE);
     view->setUrl(path);
 }

--- a/app/src/tab/remote_view.cpp
+++ b/app/src/tab/remote_view.cpp
@@ -15,7 +15,7 @@ using namespace brls::literals;
 
 class RemotePlayer : public brls::Box {
 public:
-    RemotePlayer(const remote::DirEntry& item) {
+    RemotePlayer(const remote::DirEntry& item, const std::string& method = "") {
         float width = brls::Application::contentWidth;
         float height = brls::Application::contentHeight;
         view->setDimensions(width, height);
@@ -45,12 +45,12 @@ public:
         }
 
         auto& mpv = MPVCore::instance();
-        eventSubscribeID = mpv.getEvent()->subscribe([this](MpvEventEnum event) {
+        eventSubscribeID = mpv.getEvent()->subscribe([this, method](MpvEventEnum event) {
             auto& mpv = MPVCore::instance();
             switch (event) {
             case MpvEventEnum::MPV_LOADED: {
                 if (titles.empty()) this->loadList();
-                view->getProfile()->init();
+                view->getProfile()->init(method);
                 const char* flag = MPVCore::SUBS_FALLBACK ? "select" : "auto";
                 for (auto& it : this->subtitles) {
                     mpv.command("sub-add", it.second.c_str(), flag, it.first.c_str());
@@ -89,6 +89,9 @@ public:
 
     void setList(const DirList& list, size_t index, const std::string& extra) {
         // 播放列表
+        // the constructor may have seeded a single title (standalone playback);
+        // a real list rebuilds it from scratch, otherwise titles/urls desync
+        titles.clear();
         DirList urls;
         for (size_t i = 1; i < list.size(); i++) {
             auto& it = list.at(i);
@@ -469,8 +472,8 @@ RecyclingGrid* RemoteView::newRecycler() {
     return view;
 }
 
-void RemoteView::play(const std::string& path, const std::string& name) {
-    RemotePlayer* view = new RemotePlayer({remote::EntryType::VIDEO, name, path});
+void RemoteView::play(const std::string& path, const std::string& name, const std::string& method) {
+    RemotePlayer* view = new RemotePlayer({remote::EntryType::VIDEO, name, path}, method);
     brls::Application::pushActivity(new brls::Activity(view), brls::TransitionAnimation::NONE);
     view->setUrl(path);
 }


### PR DESCRIPTION
Supersedes #8 (rebased on current `dev`, with two follow-up fixes). Credit to @dragonflylee for the original change (commit preserved).

## What it does

Routes downloaded-file playback through `RemoteView::play` instead of a hand-rolled `VideoView` (drops ~40 lines) and gives the player a real title (`name`/`method` params, `remote::DirEntry{type, name, path}`).

## Follow-up fixes (on top of #8)

1. **`titles`/`urls` desync in directory browsing.** The new `titles.push_back(item.name)` in the `RemotePlayer` ctor also fired on the browse path, which calls `setList()` right after; `setList()` didn't clear `titles`, so the seeded title stayed in front → clicked item duplicated, off-by-one track switching, last entry closing the player. Fixed by `titles.clear()` at the top of `setList()` (the standalone `setUrl` path keeps its seeded title).
2. **Downloads keep the "Local" profile label.** The old downloads player used `profile->init("Local")`; a `method` argument is now threaded `RemoteView::play → RemotePlayer → VideoProfile::init`, and `download_tab` passes `"Local"`, so the profile overlay reads "Local" as before.

## Verification

- Merges cleanly on current `dev`; the merged `RemotePlayer` also picks up the audio/subtitle OSD wiring `dev` gained after #8's base, so downloads get working track menus too.
- `DownloadItem` carries every field used by the new `detail` string (`seriesName`, `seasonIndex`, `episodeIndex`, `productionYear`, `name`).
- The dropped `view/auto_tab_frame.hpp` include is still satisfied transitively via `tab/remote_view.hpp` (`AutoTabFrame::focus2Sidebar` at `download_tab.cpp:455/525`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)