### PR TITLE
fix(remote): drop the oversized skeleton flash on folder change

### DIFF
--- a/app/src/tab/remote_view.cpp
+++ b/app/src/tab/remote_view.cpp
@@ -508,6 +508,14 @@ RecyclingGrid* RemoteView::newRecycler() {
     view->spanCount = 1;
     view->estimatedRowHeight = 48;
     view->estimatedRowSpace = 10;
+    // RecyclingGrid seeds a 12-cell skeleton (poster grid: 4 cols x 240px)
+    // in its constructor. In this single-column file browser it just flashes
+    // a screenful of oversized placeholders on every folder change — and
+    // because that skeleton overflows the viewport, reloadData scrolls to the
+    // default focus cell, which drags the floating tab bar off the top. Local
+    // listings are instant and even remote ones are quick, so drop the
+    // placeholder: an empty grid for the frame or two before the data lands.
+    view->setDataSource(nullptr);
     // inside the scroll: the list starts under the Downloads tab's
     // floating tab bar (60) and scrolls beneath it
     view->setPaddingTop(70);


### PR DESCRIPTION
## Problem

Navigating between folders in the file browser (remote/USB/local storage) had two glitches, reported after the BDMV work (#18):

1. **The top tab bar (server pills) briefly vanished** on every folder change.
2. **A screenful of skeleton placeholders flashed** even for folders with only 2–3 items.

## Root cause

`RemoteView::push` builds a fresh `RecyclingGrid` for each folder. The `RecyclingGrid` **constructor unconditionally seeds a 12-cell skeleton** sized for a poster grid (4 columns, `estimatedRowHeight` 240px). In this single-column, 48px-row file browser that skeleton:

- renders 12 oversized placeholder rows until the real listing replaces them, and
- overflows the viewport, so `reloadData` scrolls to the default focus cell — and the floating TOP tab bar, whose Y translation tracks the active grid's scroll offset (`AutoTabFrame::draw`), gets dragged off the top.

## Fix

Clear the placeholder in `newRecycler()` (`view->setDataSource(nullptr)`). Local listings are instant and remote ones are quick, so the grid simply stays empty for the frame or two before the data lands — no oversized skeleton, no scroll-induced tab-bar jump.

Trade-off: a genuinely slow remote (SFTP over a poor link) now shows a brief blank instead of a skeleton. Acceptable for a file browser, and strictly better than a placeholder flash that also hides the tabs. A deferred, right-sized skeleton (shown only after ~250ms) could be layered on later if slow-remote feedback is wanted.

## Verification

- ✅ Desktop build (`build_desktop`, x86_64) compiles + links.
- ✅ Ran the app against a local file mount: the tab bar stays put and the list appears cleanly with no skeleton clutter, on both short (Blu-ray folder) and long (30-file) directories.