### PR TITLE
fix(switch): repair the HOME tile for pleNx → GMCA self-updaters (v1.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ prepared with [git-cliff](https://git-cliff.org/) from conventional commits
 hand. For the history of the upstream project this fork is based on, see the
 [Switchfin changelog](https://github.com/dragonflylee/switchfin/blob/dev/CHANGELOG.md).
 
+## [1.0.1] - 2026-07-12
+
+Fixes the HOME-tile experience for Switch users who self-updated from pleNx to
+GMCA 1.0.0.
+
+### Fixed
+
+- **Switch HOME tile after a pleNx → GMCA self-update.** The in-app updater
+  replaces the NRO in place, so migrated users kept a binary named `pleNx.nro`
+  and an old "pleNx" forwarder tile, while the new GMCA forwarder only looked
+  for `GMCA.nro` — installing the GMCA tile would fall through to hbmenu.
+  - The GMCA forwarder now also resolves the legacy `sdmc:/switch/pleNx.nro`
+    (and `pleNx/pleNx.nro`) so an installed tile launches the app regardless.
+  - Installing the HOME tile now stages the running NRO to the canonical
+    `sdmc:/switch/GMCA.nro` first.
+  - Migrated users, who were past the one-time pleNx-era install prompt, are
+    re-offered the GMCA tile once (a GMCA-era prompt, gated separately).
+
 ## [1.0.0] - 2026-07-12
 
 First release under the new name **GMCA — Gamepad Media Center Aggregator**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ include(${BOREALIS_LIBRARY}/cmake/toolchain.cmake)
 project(GMCA)  # short token for files/binaries/IDs; display name = "Gamepad Media Center Aggregator"
 set(VERSION_MAJOR "1")
 set(VERSION_MINOR "0")
-set(VERSION_ALTER "0")
+set(VERSION_ALTER "1")
 # Homebrew forwarder title ID for GMCA, in the community forwarder range (05...),
 # which is outside Nintendo's commercial 01... space — so it cannot collide with
 # an official title, and no title-ID registry check is needed. The "GMCA" vanity

--- a/app/include/utils/config.hpp
+++ b/app/include/utils/config.hpp
@@ -145,6 +145,12 @@ public:
         /// launch in application mode (Switch).
         HINT_FORWARDER,
 
+        /// GMCA-era HOME-tile re-nudge, gated separately from HINT_FORWARDER on
+        /// purpose: pleNx users who self-updated to GMCA are past the pleNx-era
+        /// HINT_FORWARDER gate but have no GMCA tile (fresh title id), so re-offer
+        /// it exactly once so they get a tile that resolves the migrated NRO.
+        HINT_FORWARDER_GMCA,
+
         /// One-time "pleNx is now GMCA" welcome notice already shown. Set the
         /// first time the notice is displayed (only to users migrated from a
         /// legacy pleNx/Switchlex data dir — see AppConfig::migratedFromLegacy).

--- a/app/src/activity/hint_activity.cpp
+++ b/app/src/activity/hint_activity.cpp
@@ -2,6 +2,8 @@
 
 #ifdef BUILTIN_NSP
 #include <nspmini.hpp>
+#include <filesystem>
+#include "utils/config.hpp"
 #endif
 
 using namespace brls::literals;
@@ -24,6 +26,20 @@ void HintActivity::onContentAvailable() {
         dialog->addButton("hints/cancel"_i18n, []() {});
         dialog->addButton("hints/ok"_i18n, []() {
             brls::Application::blockInputs();
+            // The forwarder launches sdmc:/switch/GMCA.nro. pleNx users who
+            // self-updated in place still have the binary at the old path
+            // (AppVersion::nro_path, e.g. .../pleNx.nro), so stage it under the
+            // canonical name first — otherwise the freshly installed GMCA tile
+            // falls through to hbmenu. Best-effort; the forwarder also falls back
+            // to the legacy pleNx path.
+            try {
+                const std::string& src = AppVersion::nro_path;
+                const std::string dst = "sdmc:/switch/GMCA.nro";
+                if (src.size() > 4 && src != dst && std::filesystem::exists(src))
+                    std::filesystem::copy_file(src, dst, std::filesystem::copy_options::overwrite_existing);
+            } catch (const std::exception& e) {
+                brls::Logger::warning("forwarder: could not stage GMCA.nro: {}", e.what());
+            }
             mini::InstallSD("romfs:/forwarder.nsp");
             unsigned long long AppTitleID = mini::GetTitleID();
             appletRequestLaunchApplication(AppTitleID, NULL);

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -68,10 +68,15 @@ static bool isForwarderInstalled() {
 /// First launch in application mode: offers to install the HOME tile
 /// (launched from the tile itself or tile already there -> ns sees it -> nothing).
 static void proposeForwarderInstall() {
+    if (isForwarderInstalled()) return;  // a GMCA HOME tile is already present
+
     auto& conf = AppConfig::instance();
-    if (conf.getItem(AppConfig::HINT_FORWARDER, false)) return;
+    // One-time GMCA-era nudge, keyed separately from HINT_FORWARDER on purpose:
+    // pleNx users who self-updated to GMCA are past the pleNx-era HINT_FORWARDER
+    // gate yet have no GMCA tile (fresh title id), so re-offer it exactly once.
+    if (conf.getItem(AppConfig::HINT_FORWARDER_GMCA, false)) return;
+    conf.setItem(AppConfig::HINT_FORWARDER_GMCA, true);
     conf.setItem(AppConfig::HINT_FORWARDER, true);
-    if (isForwarderInstalled()) return;
 
     auto dialog = new brls::Dialog("main/hints/prompt"_i18n);
     dialog->addButton("hints/cancel"_i18n, []() {});

--- a/app/src/utils/config.cpp
+++ b/app/src/utils/config.cpp
@@ -111,6 +111,7 @@ std::unordered_map<AppConfig::Item, AppConfig::Option> AppConfig::settingMap = {
     {SIDEBAR_LAYOUT, {"sidebar_layout"}},
 
     {HINT_FORWARDER, {"hint_forwarder"}},
+    {HINT_FORWARDER_GMCA, {"hint_forwarder_gmca"}},
     {RENAME_NOTICE_SHOWN, {"rename_notice_shown"}},
 
     {KEY_REFRESH, {"key_refresh"}},

--- a/scripts/forwarder/source/main.c
+++ b/scripts/forwarder/source/main.c
@@ -6,6 +6,11 @@
 #define HBMENU_NRO "sdmc:/hbmenu.nro"
 #define DEFAULT_NRO "sdmc:/switch/GMCA.nro"
 #define APP_STORE_NRO "sdmc:/switch/GMCA/GMCA.nro"
+// Legacy pleNx paths: users who self-updated pleNx -> GMCA in place still have
+// the (now-GMCA) binary at the old name. Resolve it so this tile launches the
+// app instead of falling through to hbmenu, until they re-stage GMCA.nro.
+#define LEGACY_NRO "sdmc:/switch/pleNx.nro"
+#define LEGACY_APP_STORE_NRO "sdmc:/switch/pleNx/pleNx.nro"
 
 const char g_noticeText[] =
     "nx-hbloader " VERSION
@@ -323,6 +328,12 @@ void loadNro(void) {
         } else if (access(APP_STORE_NRO, F_OK) != -1) {
             memcpy(g_nextNroPath, APP_STORE_NRO, sizeof(APP_STORE_NRO));
             memcpy(g_nextArgv, APP_STORE_NRO, sizeof(APP_STORE_NRO));
+        } else if (access(LEGACY_NRO, F_OK) != -1) {
+            memcpy(g_nextNroPath, LEGACY_NRO, sizeof(LEGACY_NRO));
+            memcpy(g_nextArgv, LEGACY_NRO, sizeof(LEGACY_NRO));
+        } else if (access(LEGACY_APP_STORE_NRO, F_OK) != -1) {
+            memcpy(g_nextNroPath, LEGACY_APP_STORE_NRO, sizeof(LEGACY_APP_STORE_NRO));
+            memcpy(g_nextArgv, LEGACY_APP_STORE_NRO, sizeof(LEGACY_APP_STORE_NRO));
         } else {
             memcpy(g_nextNroPath, HBMENU_NRO, sizeof(HBMENU_NRO));
             memcpy(g_nextArgv, HBMENU_NRO, sizeof(HBMENU_NRO));


### PR DESCRIPTION
Fixes the HOME-tile break for Switch users who self-updated pleNx → GMCA 1.0.0 (NRO stays at `pleNx.nro`, GMCA forwarder wanted `GMCA.nro` → tile fell through to hbmenu; the pleNx-era install prompt never re-fired).

**A** — forwarder resolves legacy `sdmc:/switch/pleNx.nro` (+ `pleNx/pleNx.nro`) before hbmenu.
**B** — installing the HOME tile stages the running NRO → canonical `sdmc:/switch/GMCA.nro`.
**C** — re-offer the tile once via a separate `HINT_FORWARDER_GMCA` flag (reaches users already on 1.0.0).

Reuses existing hint i18n (no new strings). Bumps to **1.0.1**. Desktop build clean; `build-nx` validates the Switch paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)