### PR TITLE
fix(music): don't let a queue grab outlive the pane (#11 review)

### DIFF
--- a/app/src/view/music_now_playing.cpp
+++ b/app/src/view/music_now_playing.cpp
@@ -85,6 +85,10 @@ public:
 
     bool isGrabbed(int index) const { return this->grabbedIndex == index; }
 
+    /// Clear any active grab without reloading (the caller refreshes). Called on
+    /// a queue rebuild so a grab can never anchor to a now-stale index.
+    void resetGrab() { this->grabbedIndex = -1; }
+
     void toggleGrab(int index) {
         this->grabbedIndex = (this->grabbedIndex == index) ? -1 : index;
         this->refocus(index);
@@ -147,6 +151,15 @@ QueueCell::QueueCell() {
             return false;
         },
         true, true);
+    // While grabbed, swallow LEFT/RIGHT so focus can't leave the pane mid-move.
+    // Otherwise the grab outlives the pane: returning later and pressing A eats
+    // the first press as a drop, and a shuffle reached from the transport would
+    // strand the grab on a stale index. Not grabbed -> normal navigation.
+    brls::ActionListener swallowIfGrabbed = [this](brls::View*) {
+        return this->ds && this->ds->isGrabbed((int)this->getIndex());
+    };
+    this->registerAction("", brls::BUTTON_NAV_LEFT, swallowIfGrabbed, true, true);
+    this->registerAction("", brls::BUTTON_NAV_RIGHT, swallowIfGrabbed, true, true);
 }
 
 }  // namespace
@@ -319,6 +332,8 @@ void MusicNowPlaying::refreshRepeat() {
 }
 
 void MusicNowPlaying::rebuildQueue() {
+    // the order changed (new queue / shuffle): any grab is now meaningless
+    if (auto* ds = dynamic_cast<QueueDataSource*>(this->queueList->getDataSource())) ds->resetGrab();
     // land on the now-playing track when navigating into the pane
     this->queueList->setDefaultCellFocus((size_t)std::max(0, AudioPlayer::instance().queuePos()));
     this->queueList->reloadData();  // no-op before first layout; onLayout reloads


### PR DESCRIPTION
Follow-up addressing the code-review findings on the Now Playing queue reorder (PR #29). The grab state (`QueueDataSource::grabbedIndex`) could outlive its valid context.

## Bugs fixed
1. **Grab stranded by leaving the pane.** LEFT was not intercepted while grabbed, so pressing it moved focus out to the transport with the grab still active. Coming back and pressing **A** on that row was then consumed as a *drop* instead of playing the track — the first A did nothing.
2. **Stale grab after shuffle.** Shuffling (reached from the transport) fired `queueChanged` → `rebuildQueue()`, which reloaded the grid but left `grabbedIndex` pointing at a now-arbitrary row, so the grab marker and the next move targeted the wrong track.

## Fix
- **While grabbed, swallow LEFT/RIGHT** so focus can't leave the pane mid-move (proper grab-mode input capture). Navigation is untouched when not grabbed.
- `rebuildQueue()` **clears any grab before reloading** (belt-and-suspenders) so a grab can never anchor to a stale index.

15 lines in `music_now_playing.cpp`, no API change.

## Not addressed here (deliberately)
- The "seek bar traps LEFT/RIGHT / takes initial focus" finding was a false alarm: initial focus is `btnToggle` (`getDefaultFocus`), and LEFT/RIGHT-as-seek on the slider is intentional and matches the video OSD.
- Perf cleanup (full `reloadData` per reorder step) and the dedup refactors (grab logic vs `LibraryManager`, cover/artist fallback idiom, nav-route loop) are left for a separate hygiene pass — a correct targeted-swap needs its own implementation + verification and shouldn't ride on a correctness fix.

## Verification
In-app (`build_gmca`, Jellyfin): LEFT is a no-op while a row is grabbed (the row stays put); after dropping with Y, LEFT leaves the pane normally. Desktop build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)