### PR TITLE
fix(vita): stop Stremio GPU crashes (oversized artwork + 4K direct-play)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ prepared with [git-cliff](https://git-cliff.org/) from conventional commits
 hand. For the history of the upstream project this fork is based on, see the
 [Switchfin changelog](https://github.com/dragonflylee/switchfin/blob/dev/CHANGELOG.md).
 
+## [1.0.5] - 2026-07-13
+
+### Fixed
+
+- **PS Vita: Stremio crashed the GPU ("blue light of death") both while
+  browsing and on playback.** Two independent causes, both down to the Vita's
+  tiny GPU memory and its 1080p-capped hardware decoder:
+  - *Artwork textures were unbounded.* Unlike Plex/Jellyfin, Stremio serves
+    absolute Cinemeta poster/backdrop URLs that can't be resized server-side, so
+    a full-res 1920×1080 backdrop became a 2048×2048 GXM texture (~4 MB in DXT5);
+    a handful exhausted GPU memory and the allocator then returned null
+    mid-render, faulting the GPU. This is the crash reported "everywhere" and
+    specifically when pressing ○ to leave a movie/show overview. Artwork is now
+    downscaled to ≤1024 px per side before upload (the screen is 960×544, so this
+    is lossless even full-screen), capping every texture and quartering the
+    largest ones. As a client-side guard it also protects the other backends if
+    a server ever hands back an oversized image.
+  - *Playback had no resolution cap.* Stremio is direct-play only and sorted 4K
+    first, so the default source fed a 4K stream to a decoder that tops out at
+    1080p — an instant GPU crash. On Vita, 4K sources are now dropped and the
+    source list prefers ≤720p (the field-tested comfort zone for the Vita's
+    limited CPU), keeping 1080p only as a manual fallback. An item left with no
+    compatible source shows the existing "no sources" notice instead of crashing.
+    (#216)
+
 ## [1.0.4] - 2026-07-13
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ include(${BOREALIS_LIBRARY}/cmake/toolchain.cmake)
 project(GMCA)  # short token for files/binaries/IDs; display name = "Gamepad Media Center Aggregator"
 set(VERSION_MAJOR "1")
 set(VERSION_MINOR "0")
-set(VERSION_ALTER "4")
+set(VERSION_ALTER "5")
 # Homebrew forwarder title ID for GMCA, in the community forwarder range (05...),
 # which is outside Nintendo's commercial 01... space — so it cannot collide with
 # an official title, and no title-ID registry check is needed. The "GMCA" vanity
@@ -70,7 +70,7 @@ set(PSN_TITLE_ID "GMCA00000")
 # main version). Bumped every Vita release so the package version never
 # regresses; 00.23 shipped with the broken v1.0.3 VPK, 00.24 is the first that
 # actually installs.
-set(VITA_VERSION "00.24")
+set(VITA_VERSION "00.25")
 set(PROJECT_ICON ${CMAKE_CURRENT_SOURCE_DIR}/resources/icon/icon.jpg)
 set(PROJECT_RESOURCES ${CMAKE_CURRENT_SOURCE_DIR}/resources)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")

--- a/app/include/api/stremio/types.hpp
+++ b/app/include/api/stremio/types.hpp
@@ -538,6 +538,20 @@ inline int qualityRank(const std::string& label) {
     return 1;  // CAM
 }
 
+/// PS Vita sort rank. The hardware H.264 decoder tops out at 1080p and 4K
+/// hard-crashes the GPU (blue light), while 1080p remux bitrates stutter on the
+/// Vita's limited CPU/IO. So every <=720p source outranks 1080p, which stays
+/// only as a last-resort fallback (4K is filtered out before the sort, but is
+/// ranked lowest here as a safety net). Field-tested guidance from Vita users:
+/// keep Stremio playback at <=720p. (default pick = highest-ranked = index 0.)
+inline int qualityRankVita(const std::string& label) {
+    if (label == "720p") return 5;
+    if (label == "480p" || label == "SD") return 4;
+    if (label == "1080p") return 3;  // decodable but heavy -> fallback only
+    if (label == "4K") return 1;     // exceeds the decoder; excluded upstream
+    return 2;                        // CAM
+}
+
 /// First "<number> <GB|MB|TB>" found, normalized ("8.4 GB"). Empty if none.
 inline std::string parseSizeLabel(const std::string& text) {
     static const char* units[] = {"GB", "MB", "TB", "GiB", "MiB"};

--- a/app/src/api/stremio/backend.cpp
+++ b/app/src/api/stremio/backend.cpp
@@ -219,9 +219,24 @@ std::vector<media::Media> resolveAllStreams(
         }
         for (auto& s : streams) all.push_back(streamToMedia(s, a.manifest.name));
     }
+#if defined(__PSV__)
+    // PS Vita: 4K exceeds the hardware H.264 decoder (1080p max) and hard-crashes
+    // the GPU on play (the "blue light of death" users report). Drop every 4K
+    // source outright — better an "unsupported" message than a device freeze.
+    // 1080p is kept but demoted below every <=720p option by qualityRankVita, so
+    // the default pick (index 0) stays smooth while the heavier source remains a
+    // manual fallback. See bug #216 (crash on Vita playback).
+    all.erase(std::remove_if(all.begin(), all.end(),
+                  [](const media::Media& m) { return m.videoResolution == "4K"; }),
+        all.end());
+#endif
     std::stable_sort(all.begin(), all.end(), [](const media::Media& x, const media::Media& y) {
         if (x.playable() != y.playable()) return x.playable();  // playable first
+#if defined(__PSV__)
+        int qx = qualityRankVita(x.videoResolution), qy = qualityRankVita(y.videoResolution);
+#else
         int qx = qualityRank(x.videoResolution), qy = qualityRank(y.videoResolution);
+#endif
         if (qx != qy) return qx > qy;                           // then best quality
         if (x.playable() && x.cached != y.cached) return x.cached;  // then cached debrid first
         return false;

--- a/app/src/utils/image.cpp
+++ b/app/src/utils/image.cpp
@@ -99,6 +99,30 @@ static void dxt_compress_ext(
 static void dxt_compress(uint8_t* dst, uint8_t* src, uint32_t w, uint32_t h, bool isdxt5) {
     dxt_compress_ext(dst, src, w, h, w, 64, isdxt5);
 }
+
+// 2x box-average downscale of an RGBA8 image into a fresh (w+1)/2 x (h+1)/2
+// buffer. Each destination pixel averages its 2x2 source block; an odd last
+// row/column clamps to the edge so the shrunk image keeps a clean border. Used
+// to cap artwork size before it becomes a GXM texture (see doRequest).
+static uint8_t* halve_rgba(const uint8_t* src, int w, int h, int* outW, int* outH) {
+    int dw = (w + 1) / 2, dh = (h + 1) / 2;
+    auto* dst = (uint8_t*)malloc((size_t)dw * dh * 4);
+    if (!dst) return nullptr;
+    for (int y = 0; y < dh; y++) {
+        int sy0 = y * 2, sy1 = MIN(sy0 + 1, h - 1);
+        const uint8_t* r0 = src + (size_t)sy0 * w * 4;
+        const uint8_t* r1 = src + (size_t)sy1 * w * 4;
+        uint8_t* d = dst + (size_t)y * dw * 4;
+        for (int x = 0; x < dw; x++) {
+            int sx0 = (x * 2) * 4, sx1 = MIN(x * 2 + 1, w - 1) * 4;
+            for (int c = 0; c < 4; c++)
+                d[x * 4 + c] = (uint8_t)((r0[sx0 + c] + r0[sx1 + c] + r1[sx0 + c] + r1[sx1 + c] + 2) / 4);
+        }
+    }
+    *outW = dw;
+    *outH = dh;
+    return dst;
+}
 #endif
 
 Image::Image() : image(nullptr) {
@@ -176,6 +200,33 @@ void Image::doRequest(HTTP& s) {
         bool hasAlpha = isWebp;
 #ifdef BOREALIS_USE_GXM
         if (imageData) {
+            // Cap artwork at 1024px per side before it becomes a GXM texture.
+            // GXM rounds texture dimensions up to the next power of two, so an
+            // unresized backdrop (Stremio serves full-res Cinemeta art — its
+            // imageUrl can't resize an absolute CDN url the way Plex/Jellyfin do)
+            // at 1920x1080 turns into a 2048x2048 texture (~4 MB in DXT5). A few
+            // of those exhaust the Vita's GPU memory; the allocator then returns
+            // null mid-render and GXM faults — the "GPU crash / blue light" users
+            // hit while browsing and when leaving a media overview. The screen is
+            // 960x544, so 1024 is lossless even full-screen and quarters the
+            // texture. 2x box-averaging keeps the downscale cheap on the CPU.
+            while (imageW > 1024 || imageH > 1024) {
+                int nw, nh;
+                uint8_t* half = halve_rgba(imageData, imageW, imageH, &nw, &nh);
+                if (!half) break;
+#ifdef USE_WEBP
+                if (isWebp)
+                    WebPFree(imageData);
+                else
+#endif
+                    stbi_image_free(imageData);
+                // The shrunk buffer is a plain malloc now, so route later frees
+                // through stbi_image_free (STBI_FREE == free), not WebPFree.
+                isWebp = false;
+                imageData = half;
+                imageW = nw;
+                imageH = nh;
+            }
             // DXT1 drops the alpha channel entirely: transparent PNGs (clear
             // logos...) would expose the RGB garbage hidden under their
             // alpha-0 areas as opaque blocks. Scan the decoded pixels and

--- a/site/404.html
+++ b/site/404.html
@@ -91,7 +91,7 @@
     <p class="footer-legal">
       GMCA is an independent, third-party project, not affiliated with or endorsed by Plex, Jellyfin, Emby or Stremio.
       Nintendo Switch is a trademark of Nintendo; PS Vita is a trademark of Sony. ·
-      <span data-version>v1.0.4</span> · <a href="https://github.com/thcolin/gamepad-media-center-aggregator/blob/dev/CHANGELOG.md">Changelog</a>
+      <span data-version>v1.0.5</span> · <a href="https://github.com/thcolin/gamepad-media-center-aggregator/blob/dev/CHANGELOG.md">Changelog</a>
     </p>
   </footer>
 

--- a/site/guide.html
+++ b/site/guide.html
@@ -271,7 +271,7 @@
     <p class="footer-legal">
       GMCA is an independent, third-party project, not affiliated with or endorsed by Plex, Jellyfin, Emby or Stremio.
       Nintendo Switch is a trademark of Nintendo; PS Vita is a trademark of Sony. ·
-      <span data-version>v1.0.4</span> · <a href="https://github.com/thcolin/gamepad-media-center-aggregator/blob/dev/CHANGELOG.md">Changelog</a>
+      <span data-version>v1.0.5</span> · <a href="https://github.com/thcolin/gamepad-media-center-aggregator/blob/dev/CHANGELOG.md">Changelog</a>
     </p>
   </footer>
 

--- a/site/index.html
+++ b/site/index.html
@@ -96,7 +96,7 @@
 
         <p class="hero-sub">GMCA is one gamepad-first <strong>client</strong>. Point it at any <strong>media center</strong>, and run it on any <strong>device</strong> you left in a drawer.</p>
         <div class="hero-cta">
-          <a class="btn btn-primary" href="https://github.com/thcolin/gamepad-media-center-aggregator/releases/latest"><span class="btn-glyph">A</span> Download <span data-version>v1.0.4</span></a>
+          <a class="btn btn-primary" href="https://github.com/thcolin/gamepad-media-center-aggregator/releases/latest"><span class="btn-glyph">A</span> Download <span data-version>v1.0.5</span></a>
           <a class="btn btn-ghost" href="https://github.com/thcolin/gamepad-media-center-aggregator"><span class="btn-glyph">B</span> View on GitHub</a>
         </div>
         <p class="center-note">Free &amp; open source · Not affiliated with Plex · Jellyfin · Emby · Stremio</p>
@@ -489,7 +489,7 @@
     <p class="footer-legal">
       GMCA is an independent, third-party project, not affiliated with or endorsed by Plex, Jellyfin, Emby or Stremio.
       Nintendo Switch is a trademark of Nintendo; PS Vita is a trademark of Sony. ·
-      <span data-version>v1.0.4</span> · <a href="https://github.com/thcolin/gamepad-media-center-aggregator/blob/dev/CHANGELOG.md">Changelog</a>
+      <span data-version>v1.0.5</span> · <a href="https://github.com/thcolin/gamepad-media-center-aggregator/blob/dev/CHANGELOG.md">Changelog</a>
     </p>
   </footer>
 


### PR DESCRIPTION
## Problem

Multiple PS Vita users report Stremio **crashing the GPU** (the "blue light of death") — both **while browsing** (crashes "everywhere", notably when pressing ○ to leave a movie/show overview) and **on playback** ("click play → GPU crashes every time"). Reddit field reports converge on: keep Vita playback ≤720p.

## Root causes (two independent bugs, both app-side)

The Vita has very little GPU memory and a hardware H.264 decoder capped at 1080p.

1. **Unbounded artwork textures.** `StremioBackend::imageUrl()` returns absolute Cinemeta URLs and can't server-resize them the way Plex/Jellyfin do. A full-res 1920×1080 backdrop becomes a **2048×2048** GXM texture (~4 MB in DXT5, since GXM rounds to power-of-two). A few of those exhaust GPU memory; the allocator then returns null mid-render and GXM faults. The texture cache bounds the *count* of textures, never their *bytes*, so it can't catch this.
2. **No playback resolution cap.** Stremio is direct-play only and `resolveAllStreams` sorted **4K first**, so the default source fed a 4K stream to the 1080p-max decoder → instant GPU crash.

## Fix

- **`image.cpp` (GXM only):** box-downscale every decoded artwork to **≤1024 px per side** before the GPU upload — the screen is 960×544, so this is lossless full-screen while quartering the largest textures. Caps GPU memory deterministically for *any* image source (also guards the other backends).
- **`stremio/backend.cpp` + `types.hpp` (`__PSV__`):** drop 4K sources outright and rank **≤720p first** (`qualityRankVita`), keeping 1080p only as a manual fallback. An item left with no compatible source shows the existing "no sources" notice instead of crashing.

## Validation

- Full **vitasdk cross-build** (`-DPLATFORM_PSV=ON -DUSE_GXM=ON`) — compiles clean, produces `GMCA.vpk`.
- Runtime not exercised (no Vita hardware in CI); logic verified by review. The memory-bound fix also plausibly addresses #216 (crash on Vita playback) since it frees GPU memory for mpv's FBO/decoder init regardless of bitrate.

Closes #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)