### PR TITLE
fix(activity): avoid show battery widget in PC desktop

### DIFF
--- a/app/src/activity/main_activity.cpp
+++ b/app/src/activity/main_activity.cpp
@@ -154,8 +154,9 @@ void MainActivity::addSidebarStatus() {
     auto* wifi = new brls::WirelessWidget(0.5f);
     wifi->setMarginRight(2);
     status->addView(wifi);
-    status->addView(new brls::BatteryWidget(0.5f));
-
+    if (brls::Application::getPlatform()->canShowBatteryLevel()) {
+        status->addView(new brls::BatteryWidget(0.5f));
+    }
     footer->addView(status);
 }
 

--- a/app/src/view/connection_switcher.cpp
+++ b/app/src/view/connection_switcher.cpp
@@ -205,6 +205,7 @@ public:
             connectWithUser(u);
             return true;
         });
+        this->addGestureRecognizer(new brls::TapGestureRecognizer(this));
         this->registerAction("hints/delete"_i18n, brls::BUTTON_X, [u, parent](brls::View*) {
             Dialog::cancelable("main/setting/server/delete"_i18n, [u, parent]() {
                 AppConfig::instance().removeUser(u.id);
@@ -310,6 +311,7 @@ public:
             view->present(new ServerTypeChoose());
             return true;
         });
+        this->addGestureRecognizer(new brls::TapGestureRecognizer(this));
     }
 
     void onFocusGained() override {


### PR DESCRIPTION
Fix issue https://github.com/thcolin/gamepad-media-center-aggregator/issues/37