### PR TITLE
fix(activity): guard wireless widget where wifi info is unavailable (desktop Linux crash)

### DIFF
--- a/app/src/activity/main_activity.cpp
+++ b/app/src/activity/main_activity.cpp
@@ -141,8 +141,11 @@ void MainActivity::addSidebarStatus() {
     if (!footer) return;
 
     // wifi + battery, half the status-bar size and dimmed, in a row at the very
-    // bottom of the pinned footer (appended after the gear). The widgets
-    // gracefully collapse to nothing on platforms without battery/wireless info.
+    // bottom of the pinned footer (appended after the gear). Each widget is added
+    // only when the platform can actually report that info: otherwise its ctor
+    // early-returns and leaves its members null, but draw() dereferences them
+    // anyway (null-deref crash — battery on a PC with no battery, see #37; wifi on
+    // desktop Linux where canShowWirelessLevel() is false).
     auto* status = new brls::Box();
     status->setAxis(brls::Axis::ROW);
     status->setJustifyContent(brls::JustifyContent::CENTER);
@@ -151,10 +154,13 @@ void MainActivity::addSidebarStatus() {
     status->setMarginBottom(2);
     status->setAlpha(0.6f);
 
-    auto* wifi = new brls::WirelessWidget(0.5f);
-    wifi->setMarginRight(2);
-    status->addView(wifi);
-    if (brls::Application::getPlatform()->canShowBatteryLevel()) {
+    auto* platform = brls::Application::getPlatform();
+    if (platform->canShowWirelessLevel()) {
+        auto* wifi = new brls::WirelessWidget(0.5f);
+        wifi->setMarginRight(2);
+        status->addView(wifi);
+    }
+    if (platform->canShowBatteryLevel()) {
         status->addView(new brls::BatteryWidget(0.5f));
     }
     footer->addView(status);


### PR DESCRIPTION
Follow-up to #38 (thanks @dragonflylee).

#38 fixed the `BatteryWidget` null-deref (#37) by only adding the widget when the platform can report battery info. The `WirelessWidget` right above it in `addSidebarStatus` has the **exact same partial-construction flaw** and was still added unconditionally:

- ctor early-returns when `!canShowWirelessLevel()`, leaving `_0/_1/.../ethernet` null;
- `WirelessWidget::draw()` dereferences them every frame regardless;
- `DesktopPlatform::canShowWirelessLevel()` returns `false` on the `#else` branch — i.e. **desktop Linux**.

So our shipped **Flatpak / AUR** builds would hit the identical crash of #37, just on the wifi widget instead of the battery one.

## Fix

Guard the wifi widget at the call site the same way #38 guards the battery widget (guarding creation, not just `addView`, so we don't leak the widget when it isn't shown). Also fixed the now-inaccurate "gracefully collapse to nothing" comment — that assumption is precisely what caused #37.

## Note on the root cause

The durable fix lives in `borealis`: both `BatteryWidget::draw()` and `WirelessWidget::draw()` should early-return on `!canShow…Level()` so the widgets are self-safe for any caller. Since both are used in exactly one place (here), the call-site guard fully covers GMCA; the upstream `draw()` guard is a separate follow-up (flagged to @dragonflylee on #38).

Refs #37, #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)
