### PR TITLE
refactor(download): document dedicated HTTP session on the pool task

### DIFF
--- a/app/src/utils/download.cpp
+++ b/app/src/utils/download.cpp
@@ -360,7 +360,8 @@ void DownloadManager::processQueue() {
     }
 }
 
-// Must be called with mutex held. Copies what it needs, then releases via async.
+// Must be called with mutex held. Copies what it needs, then hands the transfer
+// off to a ThreadPool worker.
 void DownloadManager::doDownload(DownloadItem& item) {
     item.status = DownloadStatus::Downloading;
 
@@ -377,7 +378,11 @@ void DownloadManager::doDownload(DownloadItem& item) {
 
     brls::sync([this, itemId]() { this->statusEvent.fire(itemId, DownloadStatus::Downloading); });
 
-    ThreadPool::instance().submit([this, itemId, thumb, partKey, url, itemDir, cancel](HTTP& s) {
+    // Runs on a ThreadPool worker. We deliberately ignore the pool's shared
+    // per-worker HTTP session and open a fresh one below: this transfer installs
+    // a progress callback + cancel token that would otherwise linger on the
+    // shared session and leak into the next image/version task on that worker.
+    ThreadPool::instance().submit([this, itemId, thumb, partKey, url, itemDir, cancel](HTTP&) {
         auto resetQueue = [this, itemId](const std::string& error) {
             brls::sync([this, itemId, error]() {
                 {


### PR DESCRIPTION
Suivi de #39 (`fix(download): using threadpool for offline download`).

#39 a déplacé le download hors-ligne de `brls::async` vers `ThreadPool::submit`, dont la tâche reçoit la session HTTP partagée du worker (`HTTP& s`). Le download ne doit **pas** la réutiliser : il installe un progress callback + cancel token qui resteraient collés sur la session partagée et fuiteraient vers la tâche image/version suivante du même worker. Il ouvre donc une `HTTP` fraîche localement — ce qui était correct, mais implicite.

Ce PR rend l'intention explicite, sans changement de comportement :

- supprime le nom du paramètre inutilisé (`HTTP& s` → `HTTP&`), qui était par ailleurs masqué (shadow) par le `HTTP` local ;
- ajoute un commentaire expliquant pourquoi une session dédiée est utilisée plutôt que celle du pool ;
- corrige le commentaire obsolète `// ... releases via async.` (ce n'est plus `brls::async` mais le ThreadPool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)