### PR TITLE
fix(connection): race server candidates in parallel for WAN reconnects (#36)

### DIFF
--- a/app/include/activity/loading_activity.hpp
+++ b/app/include/activity/loading_activity.hpp
@@ -1,8 +1,8 @@
 /*
     Full-screen loading screen: spinner + "Connecting to server...".
-    Shown while probing the server URLs (plex::probeConnection, 2 s timeout
-    per URL, in series — plex.direct servers often advertise 10+ connections
-    including unreachable local IPs), both at startup (AppConfig::checkLogin)
+    Shown while probing the server URLs (plex::raceConnections — plex.direct
+    servers often advertise 10+ connections including unreachable local IPs, so
+    the candidates are raced in parallel), both at startup (AppConfig::checkLogin)
     and when selecting a profile (ServerList).
 */
 

--- a/app/include/api/http.hpp
+++ b/app/include/api/http.hpp
@@ -32,7 +32,13 @@ public:
     };
 
     struct Timeout {
+        // Whole-request budget in ms (-1 = unlimited). `connect` is the
+        // connect+DNS budget: keeping it shorter than `timeout` lets an
+        // unreachable host fail fast while a reachable but high-latency endpoint
+        // still gets the full budget to complete its TLS handshake + response
+        // (GH #36 — roaming/WAN probes). `connect <= 0` keeps them identical.
         long timeout = TIMEOUT;
+        long connect = 0;
     };
 
     struct Cookie {

--- a/app/include/api/plex/auth.hpp
+++ b/app/include/api/plex/auth.hpp
@@ -36,19 +36,29 @@ std::vector<HomeUser> getHomeUsers(const std::string& accountToken);
 std::string switchHomeUser(const std::string& accountToken, const std::string& userUuid, const std::string& pin = "");
 
 /// Probes a base URL (GET {base}/ with token); returns true on 200.
-bool probeConnection(const std::string& baseUrl, const std::string& accessToken, long timeoutMs = 2000);
+/// `connectMs` bounds the connect+DNS phase so an unreachable host fails fast,
+/// while the larger `timeoutMs` lets a reachable but high-latency endpoint
+/// finish its TLS handshake + response (GH #36).
+bool probeConnection(const std::string& baseUrl, const std::string& accessToken, long timeoutMs = 5000,
+    long connectMs = 2000);
 
 /// Candidate base URLs of a server, ordered by priority (https+local ->
 /// https+remote -> https+relay -> http...) WITHOUT probing any of them.
 /// Used to persist a server's connection list ahead of a lazy probe at switch
-/// time; findBestConnection probes this list in order.
+/// time; raceConnections probes this list.
 std::vector<std::string> rankConnections(const ServerResource& server);
 
-/// Picks the best connection for a server: tries `preferredUri` then the
-/// candidates by priority https+local -> https+remote -> https+relay -> http...
-/// Returns the reachable base URL, or "".
-/// NOTE: sequential probing for now; racing all candidates in parallel is a
-/// planned phase 2 optimization.
+/// Probes `urls` (a priority-ordered candidate list) CONCURRENTLY and returns
+/// the highest-priority one that answers, or "". Racing matters off-network:
+/// probed serially, every unreachable LAN address (ranked first) had to hit its
+/// connect timeout before a reachable remote/relay endpoint was even tried, so a
+/// roaming connect stalled for many seconds or gave up (GH #36). Priority is
+/// still honoured — a lower-ranked candidate wins only once every better one has
+/// failed. Shared by every backend (Plex/Jellyfin/Emby) via the reconnect paths.
+std::string raceConnections(const std::vector<std::string>& urls, const std::string& accessToken);
+
+/// Picks the best connection for a server: races `preferredUri` (if any) ahead
+/// of the ranked candidates and returns the first reachable base URL, or "".
 std::string findBestConnection(const ServerResource& server, const std::string& preferredUri = "");
 
 }  // namespace plex

--- a/app/src/api/http.cpp
+++ b/app/src/api/http.cpp
@@ -180,7 +180,7 @@ void HTTP::set_option(const Range& r) {
 
 void HTTP::set_option(const Timeout& t) {
     curl_easy_setopt(this->easy, CURLOPT_TIMEOUT_MS, t.timeout);
-    curl_easy_setopt(this->easy, CURLOPT_CONNECTTIMEOUT_MS, t.timeout);
+    curl_easy_setopt(this->easy, CURLOPT_CONNECTTIMEOUT_MS, t.connect > 0 ? t.connect : t.timeout);
 }
 
 int HTTP::easy_progress_cb(void* clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow) {

--- a/app/src/api/plex_auth.cpp
+++ b/app/src/api/plex_auth.cpp
@@ -5,8 +5,12 @@
 
 #include "api/plex/auth.hpp"
 #include "api/plex.hpp"
+#include "utils/thread.hpp"
 #include <cctype>
 #include <cstdio>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
 
 namespace plex {
 
@@ -124,15 +128,68 @@ std::string switchHomeUser(const std::string& accountToken, const std::string& u
     });
 }
 
-bool probeConnection(const std::string& baseUrl, const std::string& accessToken, long timeoutMs) {
+bool probeConnection(const std::string& baseUrl, const std::string& accessToken, long timeoutMs, long connectMs) {
     // GET {base}/ WITH token: the root requires authentication, which
-    // immediately detects a revoked token
+    // immediately detects a revoked token. A short connect budget lets an
+    // unreachable LAN address fail fast; the larger total budget leaves room for
+    // a reachable but high-latency remote/relay handshake (GH #36).
     try {
-        HTTP::get(baseUrl + "/", headers(accessToken), HTTP::Timeout{timeoutMs});
+        HTTP::get(baseUrl + "/", headers(accessToken), HTTP::Timeout{timeoutMs, connectMs});
         return true;
     } catch (const std::exception& ex) {
         brls::Logger::debug("plex probe {} en échec : {}", baseUrl, ex.what());
         return false;
+    }
+}
+
+std::string raceConnections(const std::vector<std::string>& urls, const std::string& accessToken) {
+    if (urls.empty()) return "";
+    if (urls.size() == 1) return probeConnection(urls.front(), accessToken) ? urls.front() : "";
+
+    // Probe every candidate at once on the shared thread pool, then return the
+    // best-ranked one that answers. Priority is preserved without waiting on
+    // dead candidates: a candidate wins as soon as it succeeds AND every
+    // higher-ranked candidate has already failed. The state is heap-owned so the
+    // still-running probes stay valid after we return early (they only touch
+    // `state`, never this stack frame).
+    enum Status { Pending, Reachable, Unreachable };
+    struct RaceState {
+        std::mutex mutex;
+        std::condition_variable cond;
+        std::vector<Status> status;
+    };
+    auto state = std::make_shared<RaceState>();
+    state->status.assign(urls.size(), Pending);
+
+    for (size_t i = 0; i < urls.size(); i++) {
+        std::string url = urls[i];
+        ThreadPool::instance().submit([state, url, accessToken, i](HTTP&) {
+            // Guard against any stray throw so status[i] is always decided and
+            // the waiter below never blocks forever (probeConnection already
+            // swallows std::exception; this covers the pathological rest).
+            Status result = Unreachable;
+            try {
+                if (probeConnection(url, accessToken)) result = Reachable;
+            } catch (...) {
+            }
+            {
+                std::lock_guard<std::mutex> lock(state->mutex);
+                state->status[i] = result;
+            }
+            state->cond.notify_all();
+        });
+    }
+
+    std::unique_lock<std::mutex> lock(state->mutex);
+    for (;;) {
+        size_t i = 0;
+        for (; i < urls.size(); i++) {
+            if (state->status[i] == Pending) break;         // best candidate not yet decided: keep waiting
+            if (state->status[i] == Reachable) return urls[i];  // best decided candidate answers: winner
+            // Unreachable: a better candidate is ruled out, look at the next one
+        }
+        if (i == urls.size()) return "";  // every candidate decided, none reachable
+        state->cond.wait(lock);
     }
 }
 
@@ -195,15 +252,12 @@ std::vector<std::string> rankConnections(const ServerResource& server) {
 }
 
 std::string findBestConnection(const ServerResource& server, const std::string& preferredUri) {
-    // Remembered endpoint first, with a shorter timeout (first phase of the
-    // connection race)
-    if (!preferredUri.empty() && probeConnection(preferredUri, server.accessToken, 1500)) return preferredUri;
-
-    for (auto& url : rankConnections(server)) {
-        if (url == preferredUri) continue;  // already probed above
-        if (probeConnection(url, server.accessToken)) return url;
-    }
-    return "";
+    // Race the remembered endpoint (if any) ahead of the ranked candidates.
+    std::vector<std::string> urls;
+    if (!preferredUri.empty()) urls.push_back(preferredUri);
+    for (auto& url : rankConnections(server))
+        if (url != preferredUri) urls.push_back(url);
+    return raceConnections(urls, server.accessToken);
 }
 
 }  // namespace plex

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -179,11 +179,11 @@ int main(int argc, char* argv[]) {
     } else if (items.size() > 0) {
         RemoteView::play(items.front());
     } else {
-        // checkLogin() serially probes the remembered URLs of the active
-        // server (2 s timeout per URL, config.cpp:checkLogin): called here
-        // on the main thread it froze the very first frame for several
-        // seconds (changed network, server off...). Show the loading
-        // screen and probe in the background.
+        // checkLogin() probes the remembered URLs of the active server
+        // (config.cpp:checkLogin, now raced in parallel): called here on the
+        // main thread it froze the very first frame for several seconds
+        // (changed network, server off...). Show the loading screen and probe
+        // in the background.
         brls::Application::pushActivity(new LoadingActivity(), brls::TransitionAnimation::NONE);
         brls::Application::blockInputs();
         brls::async([]() {

--- a/app/src/tab/plex_add.cpp
+++ b/app/src/tab/plex_add.cpp
@@ -228,10 +228,10 @@ void PlexAdd::finishAll(const std::string& uuid, const std::string& name, const 
     const std::string& plexTvToken, const std::vector<plex::ServerResource>& servers) {
     // Activate the first owned server (a server you own is the natural landing
     // point), else the first available. Only THIS server is probed now:
-    // findBestConnection races its candidates in series (2 s each; plex.direct
-    // servers advertise 10+), so probing every server would take far too long.
-    // The other servers store their ranked candidate urls and resolve a
-    // reachable one lazily when the user switches to them (connectWithUser).
+    // findBestConnection races its candidates in parallel, but probing every
+    // server up front would still multiply the work needlessly. The other
+    // servers store their ranked candidate urls and resolve a reachable one
+    // lazily when the user switches to them (connectWithUser).
     size_t primaryIdx = 0;
     for (size_t i = 0; i < servers.size(); i++) {
         if (servers[i].owned) {

--- a/app/src/utils/config.cpp
+++ b/app/src/utils/config.cpp
@@ -596,25 +596,27 @@ bool AppConfig::checkLogin() {
     auto it = std::find_if(this->servers.begin(), this->servers.end(), is_server);
     if (it == this->servers.end() || it->urls.empty()) return false;
 
-    // Probes the remembered connections (the last reachable one is first).
-    // No dependency on plex.tv here: a reachable LAN server is enough.
-    // Stremio has no single reachable "server" (it is an aggregate of remote
-    // addons + an optional account); skip the probe and accept the stored entry.
-    for (auto& url : it->urls) {
-        if (it->type != "stremio" && !plex::probeConnection(url, it->access_token)) continue;
-        this->server_url = url;
-        this->server_token = it->access_token;
-        this->resetBackend();
-        this->applyTheme(backendTypeFromString(it->type));
-        if (url != it->urls.front()) {
-            AppServer front = *it;
-            front.urls = {url};
-            this->addServer(front);
-        }
-        return true;
+    // Reconnect to a remembered endpoint. No dependency on plex.tv here: a
+    // reachable stored URL is enough. The candidates are raced in parallel so an
+    // unreachable LAN address no longer blocks a reachable remote/relay one while
+    // roaming (GH #36). Stremio has no single reachable "server" (it aggregates
+    // remote addons + an optional account); skip the probe, accept the stored one.
+    std::string url = it->type == "stremio" ? (it->urls.empty() ? std::string() : it->urls.front())
+                                            : plex::raceConnections(it->urls, it->access_token);
+    if (url.empty()) {
+        brls::Logger::warning("AppConfig checkLogin: aucun endpoint joignable pour {}", it->name);
+        return false;
     }
-    brls::Logger::warning("AppConfig checkLogin: aucun endpoint joignable pour {}", it->name);
-    return false;
+    this->server_url = url;
+    this->server_token = it->access_token;
+    this->resetBackend();
+    this->applyTheme(backendTypeFromString(it->type));
+    if (url != it->urls.front()) {
+        AppServer front = *it;
+        front.urls = {url};
+        this->addServer(front);
+    }
+    return true;
 }
 
 std::string AppConfig::configDir() { return dataDir(AppVersion::getPackageName()); }

--- a/app/src/utils/offline_ui.cpp
+++ b/app/src/utils/offline_ui.cpp
@@ -8,7 +8,7 @@ using namespace brls::literals;
 
 void offline_ui::tryReconnect() {
     brls::Application::notify("main/download/reconnecting"_i18n);
-    // checkLogin probes the remembered URLs (2 s each) — must run off the UI thread
+    // checkLogin probes the remembered URLs (raced in parallel) — must run off the UI thread
     brls::async([]() {
         bool ok = AppConfig::instance().checkLogin();
         brls::sync([ok]() {

--- a/app/src/view/connection_switcher.cpp
+++ b/app/src/view/connection_switcher.cpp
@@ -123,12 +123,11 @@ static void connectWithUser(const AppUser& u) {
             }
 
             // Stremio has no single reachable endpoint: accept the stored url.
-            std::string base;
-            for (auto& url : target.urls) {
-                if (target.type != "stremio" && !plex::probeConnection(url, target.access_token)) continue;
-                base = url;
-                break;
-            }
+            // Otherwise race the stored candidates in parallel so an unreachable
+            // LAN address does not block a reachable remote/relay one (GH #36).
+            std::string base = target.type == "stremio"
+                                   ? (target.urls.empty() ? std::string() : target.urls.front())
+                                   : plex::raceConnections(target.urls, target.access_token);
             if (base.empty() && fresh) base = plex::findBestConnection(*fresh);
             if (base.empty()) throw std::runtime_error(unreachable);
 


### PR DESCRIPTION
Fixes #36.

## Symptôme

Un utilisateur en voyage (hors de son réseau local) est forcé de se reconnecter après une mise à jour. Le login Plex réussit, puis l'écran « Connecting to the server… » **échoue** avec « Server unreachable » — alors que l'accès distant du serveur fonctionne parfaitement depuis les autres apps Plex (iPhone, Plexamp).

## Origine du bug

Le problème est dans la **sélection de connexion serveur**, un chemin **partagé par tous les backends serveur** (Plex/Jellyfin/Emby) via `plex::probeConnection` — pas spécifique à Plex. Deux causes se cumulent :

1. **Sondage strictement séquentiel.** `rankConnections` classe les candidats LAN en premier. Hors réseau, chaque adresse locale injoignable devait épuiser son timeout de connexion **avant** que l'endpoint distant/relay joignable ne soit ne serait-ce qu'essayé. Avec les « 10+ » connexions qu'annoncent les serveurs plex.direct (LAN multiples, IPv6, Docker, VPN), l'endpoint joignable était atteint très tard, voire jamais.

2. **Budget unique de 2 s trop court.** `set_option(Timeout)` mettait `CURLOPT_TIMEOUT_MS` **et** `CURLOPT_CONNECTTIMEOUT_MS` à la même valeur, donc 2 s couvraient toute la requête (connexion + handshake TLS + réponse). Une poignée de main distante en latence WAN/mobile (utilisateur en voyage) ne tient pas dans 2 s → la sonde d'un endpoint pourtant joignable abandonne.

Combinées : le sondage sériel gaspille le budget sur les candidats LAN morts, puis le timeout trop court tue les sondes distant/relay survivantes → `findBestConnection` renvoie `""` → « Server unreachable ».

La course parallèle était déjà annotée comme optimisation prévue (`auth.hpp`, `PLEX_MIGRATION.md §2.3`).

## Correctif

- **`HTTP::Timeout`** gagne un budget `connect` distinct. `probeConnection` utilise désormais un budget de connexion court (échec rapide sur une adresse LAN morte) et un budget total généreux (marge pour un handshake TLS distant lent). Rétrocompatible : `connect <= 0` garde l'ancien comportement.
- **`plex::raceConnections`** sonde tous les candidats **en parallèle** sur le `ThreadPool` partagé et renvoie le candidat le mieux classé qui répond. La priorité est préservée (https>http, local>remote>relay) : un candidat moins prioritaire ne gagne qu'une fois **tous** les meilleurs échoués — sans attendre les candidats morts. L'état est alloué sur le tas (`shared_ptr`) pour que les sondes encore en vol après un retour anticipé restent valides.
- **`findBestConnection`**, **`AppConfig::checkLogin`** et le **switcher de connexion** passent tous par `raceConnections`.

### Pourquoi le `ThreadPool` partagé est sûr ici
- Les téléchargements sont **sérialisés** (`processQueue` s'arrête si `downloading`), donc au plus 1 worker est occupé → il reste toujours ≥1 worker libre (même sur Vita, 2 workers).
- Aux moments critiques (startup `checkLogin`, login `finishAll`), aucun téléchargement ne tourne → pool entièrement libre → parallélisme complet.
- Les chemins de reconnexion tournent hors du thread UI ; le thread appelant n'est jamais un worker du pool (pas d'auto-deadlock).
- Une garde `catch(...)` garantit qu'une sonde marque toujours son état → l'attente ne peut jamais se bloquer indéfiniment.

## Scénario corrigé

Login hors réseau → `findBestConnection` → `raceConnections` sonde en parallèle : les candidats LAN échouent à la connexion (~2 s), le candidat distant/relay réussit son handshake dans le budget total (~5 s), et est renvoyé dès que les candidats LAN mieux classés ont échoué. Connexion établie en ~2 s au lieu d'un échec.

## Vérification

⚠️ Non compilé/exécuté localement : le sous-module `borealis` n'est pas présent dans cet environnement et le harnais de tests standalone (`tests/run.sh`) ne link aucun `.cpp` de l'app (il ne teste que du header-only). La logique de course/timeouts est comportementale (réseau + threads) et n'est pas couvrable par ce harnais. Le correctif repose sur la revue et sera validé par le build CI multi-plateformes. Test manuel recommandé : se connecter à un serveur depuis un réseau distant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)