### PR TITLE
fix(stremio): re-sync the account addon collection at startup

### DIFF
--- a/app/include/api/stremio/auth.hpp
+++ b/app/include/api/stremio/auth.hpp
@@ -30,6 +30,13 @@ struct Account {
 /// HTTP/parse failure or on an `{"error":{…}}` envelope (message preserved).
 Account login(const std::string& email, const std::string& password);
 
+/// POST /api/addonCollectionGet → transportUrls of the account's remote addons
+/// (local 127.0.0.1/localhost ones filtered out). Also used to re-sync the
+/// collection after login: Stremio (re)configures an addon by REPLACING its
+/// transportUrl (e.g. Torrentio's debrid apikey lives in the URL path), so a
+/// list snapshotted at login goes stale (GH #46). Throws std::runtime_error.
+std::vector<std::string> fetchAddonCollection(const std::string& authKey);
+
 // ---- account datastore: the user's "library" (= watchlist) + playback state ----
 // All synchronous (call from brls::async); throw std::runtime_error on failure.
 

--- a/app/include/utils/config.hpp
+++ b/app/include/utils/config.hpp
@@ -239,6 +239,9 @@ public:
     /// Stremio only: addon transport URLs of the active server (manifest URLs).
     /// Empty for other backends / when not logged in.
     const std::vector<std::string>& getStremioAddons() const;
+    /// Stremio only: replace the active server's addon list (after an account
+    /// collection re-sync) and persist. No-op when unchanged or not logged in.
+    void setStremioAddons(const std::vector<std::string>& addons);
     /// Active media backend (built lazily from the active server's type).
     /// The UI talks to this; it never formats a provider URL itself.
     media::Backend& backend();

--- a/app/src/api/stremio/addons.cpp
+++ b/app/src/api/stremio/addons.cpp
@@ -1,10 +1,11 @@
 /*
     GMCA — Stremio addon engine implementation (see stremio/addons.hpp).
-    Loads the configured transportUrls' manifests once, then routes resource
-    queries across them.
+    Re-syncs the account's addon collection, then loads the configured
+    transportUrls' manifests once and routes resource queries across them.
 */
 
 #include "api/stremio/addons.hpp"
+#include "api/stremio/auth.hpp"
 #include "utils/config.hpp"
 #include <borealis/core/logger.hpp>
 #include <algorithm>
@@ -14,6 +15,24 @@ namespace stremio {
 void AddonEngine::ensureLoaded() {
     std::lock_guard<std::mutex> lock(mtx);
     if (loaded) return;
+
+    // Re-sync the account's addon collection before loading manifests. Stremio
+    // (re)configures an addon by REPLACING its transportUrl (e.g. Torrentio's
+    // debrid apikey lives in the URL path) and the official clients pull the
+    // collection at every startup — a list snapshotted at login goes stale and
+    // keeps serving raw-torrent streams instead of debrid links (GH #46). On
+    // failure (offline, expired key) keep the stored list; an empty collection
+    // is ignored too (a live account always has the default addons) rather
+    // than wiping a working list.
+    const std::string& authKey = AppConfig::instance().getToken();
+    if (!authKey.empty()) {
+        try {
+            std::vector<std::string> fresh = fetchAddonCollection(authKey);
+            if (!fresh.empty()) AppConfig::instance().setStremioAddons(fresh);
+        } catch (const std::exception& ex) {
+            brls::Logger::warning("stremio: addon collection sync failed: {}", ex.what());
+        }
+    }
 
     // AppConfig::instance().getStremioAddons() returns the configured list of
     // transportUrls (each ending in /manifest.json). Provided by the config layer.

--- a/app/src/api/stremio/auth.cpp
+++ b/app/src/api/stremio/auth.cpp
@@ -72,17 +72,23 @@ Account login(const std::string& email, const std::string& password) {
     if (a.userId.empty()) a.userId = email;
 
     // 2. Addon collection -> remote transport URLs (skip local addons).
-    nlohmann::json collBody = {{"authKey", a.authKey}, {"update", true}};
-    nlohmann::json coll = postEnvelope(base + "/api/addonCollectionGet", collBody);
+    a.addons = fetchAddonCollection(a.authKey);
+
+    return a;
+}
+
+std::vector<std::string> fetchAddonCollection(const std::string& authKey) {
+    nlohmann::json body = {{"authKey", authKey}, {"update", true}};
+    nlohmann::json coll = postEnvelope("https://api.strem.io/api/addonCollectionGet", body);
+    std::vector<std::string> out;
     if (coll.contains("addons") && coll["addons"].is_array()) {
         for (auto& d : coll["addons"]) {
             std::string transportUrl = jstr(d, "transportUrl");
             if (transportUrl.empty() || isLocalAddon(transportUrl)) continue;
-            a.addons.push_back(transportUrl);
+            out.push_back(transportUrl);
         }
     }
-
-    return a;
+    return out;
 }
 
 std::string nowIso() {

--- a/app/src/utils/config.cpp
+++ b/app/src/utils/config.cpp
@@ -587,6 +587,17 @@ const std::vector<std::string>& AppConfig::getStremioAddons() const {
     return empty;
 }
 
+void AppConfig::setStremioAddons(const std::vector<std::string>& addons) {
+    if (this->user == this->users.end()) return;
+    for (auto& s : this->servers) {
+        if (s.id != this->user->server_id) continue;
+        if (s.addons == addons) return;  // no disk write when nothing changed
+        s.addons = addons;
+        this->save();
+        return;
+    }
+}
+
 bool AppConfig::checkLogin() {
     auto is_user = [this](const AppUser& u) { return u.id == this->user_id; };
     this->user = std::find_if(this->users.begin(), this->users.end(), is_user);


### PR DESCRIPTION
Fixes #46.

## Problem

GMCA already supports debrid-resolved streams from any service (AllDebrid included — `detectDebrid` recognizes the `[AD` label): playability only depends on the addon returning a resolved `url` instead of a raw `infoHash`. But the account's addon collection was fetched **once at login** (`stremio::login` → `AppServer.addons`) and never refreshed afterwards.

Stremio (re)configures an addon by **replacing its transportUrl** — Torrentio's debrid apikey lives in the URL path (`…/alldebrid=KEY/manifest.json`). So a user who enabled AllDebrid in Torrentio *after* connecting their account to GMCA kept hitting the old, non-debrid Torrentio URL: every stream came back infoHash-only and surfaced as *"This source is a raw torrent"*, while the official Stremio app — which pulls the collection at every startup — showed the same sources as playable `Torrentio AD+` links.

## Fix

Mirror the official client behavior: `AddonEngine::ensureLoaded()` now re-syncs the collection before loading manifests, once per backend activation (app start / server switch), on the worker thread it already runs on.

- `fetchAddonCollection(authKey)` extracted from `login()` in `auth.cpp` (same endpoint, same local-addon filter), reused by both.
- `AppConfig::setStremioAddons()` persists the fresh list on the active server (no disk write when unchanged).
- Fallbacks: network failure / expired authKey → warning logged, stored list kept; empty collection (a live account always has the default addons) → ignored rather than wiping a working list. Behavior is never worse than before.

## Verification

- Desktop build (macOS x86_64) compiles and the bundled binary smoke-tests OK.
- Error-envelope fallback confirmed empirically: `POST /api/addonCollectionGet` with an invalid authKey returns `{"error":{"code":1,"message":"Session does not exist"}}` → `postEnvelope` throws → `ensureLoaded` keeps the stored list.

**Workaround for affected users on current releases**: remove and re-add the Stremio account in GMCA (re-login re-syncs the collection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)