### PR TITLE
fix(recycling): default focus on the lowest-index cell, not insertion order

### DIFF
--- a/app/include/view/recycling_grid.hpp
+++ b/app/include/view/recycling_grid.hpp
@@ -202,6 +202,11 @@ public:
     float itemExtraHeight = 0;
 
 private:
+    /// Lowest-index attached focusable cell (nullptr if none / only skeletons).
+    /// contentBox children are in recycle (insertion) order, not index order, so
+    /// "first child" is not the top-left cell once the grid has scrolled.
+    brls::View* firstCellFocus();
+
     bool layouted = false;
     float oldWidth = -1;
 

--- a/app/src/view/recycling_grid.cpp
+++ b/app/src/view/recycling_grid.cpp
@@ -641,6 +641,26 @@ float RecyclingGrid::getHeightByCellIndex(size_t index, size_t start) {
 
 void RecyclingGrid::forceRequestNextPage() { this->requestNextPage = false; }
 
+brls::View* RecyclingGrid::firstCellFocus() {
+    // contentBox children are in recycle (insertion) order, not index order, so
+    // the top-left cell is the one with the lowest index, not the first child.
+    // Read-only (no materialization): safe to call from focus-traversal probes.
+    brls::View* target = nullptr;
+    size_t best = 0;
+    for (auto* child : this->contentBox->getChildren()) {
+        void* ud = child->getParentUserData();
+        if (!ud) continue;  // scrolled header: not a cell
+        brls::View* focus = child->getDefaultFocus();
+        if (!focus) continue;  // skeleton / non-focusable cell
+        size_t index = *((size_t*)ud);
+        if (!target || index < best) {
+            target = focus;
+            best = index;
+        }
+    }
+    return target;
+}
+
 brls::View* RecyclingGrid::getNextCellFocus(brls::FocusDirection direction, brls::View* currentView) {
     void* parentUserData = currentView->getParentUserData();
 
@@ -669,24 +689,11 @@ brls::View* RecyclingGrid::getNextCellFocus(brls::FocusDirection direction, brls
     // crashed). Handle the header explicitly.
     if (!parentUserData) {
         if (direction == brls::FocusDirection::DOWN) {
-            // Enter the grid on its FIRST cell — the lowest index, not the first
-            // in child insertion order (recycling appends cells out of order).
-            // While only skeletons are attached, stay on the header rather than
-            // ejecting focus out of the grid.
-            View* target = nullptr;
-            size_t best = 0;
-            for (auto it : this->contentBox->getChildren()) {
-                void* ud = it->getParentUserData();
-                if (!ud) continue;  // the header itself
-                View* focus = it->getDefaultFocus();
-                if (!focus) continue;  // skeleton / non-focusable cell
-                size_t index = *((size_t*)ud);
-                if (!target || index < best) {
-                    target = focus;
-                    best = index;
-                }
-            }
-            return target ? target : currentView;  // currentView == header: stay put
+            // Enter the grid on its first cell (by index). While only skeletons
+            // are attached, stay on the header rather than ejecting focus out of
+            // the grid.
+            View* cell = firstCellFocus();
+            return cell ? cell : currentView;  // currentView == header: stay put
         }
         return leaveGrid(nullptr);
     }
@@ -837,15 +844,16 @@ brls::View* RecyclingGrid::getDefaultFocus() {
     if (!this->dataSource || this->dataSource->getItemCount() == 0) return nullptr;
     brls::View* cell = ScrollingFrame::getDefaultFocus();
     if (cell) return cell;
-    // giveFocus via a navigation route: target the first already attached
-    // cell (focusable — skeletons are not). NO materialization here:
-    // getDefaultFocus is probed by navigation traversals, mutating the
-    // content at that point wreaks havoc.
-    for (auto* child : this->contentBox->getChildren()) {
-        brls::View* focus = child->getDefaultFocus();
-        if (focus) return focus;
+    // giveFocus via a navigation route. NO materialization here: getDefaultFocus
+    // is probed by navigation traversals, mutating the content at that point
+    // wreaks havoc — only read already attached, focusable views.
+    // The scrolled header keeps priority when it carries focus (its widgets are
+    // the page's primary action, e.g. the artist Shuffle button); otherwise land
+    // on the first cell BY INDEX (not child insertion order — see firstCellFocus).
+    if (this->headerView) {
+        if (brls::View* header = this->headerView->getDefaultFocus()) return header;
     }
-    return nullptr;
+    return firstCellFocus();
 }
 
 brls::View* RecyclingGrid::create() { return new RecyclingGrid(); }


### PR DESCRIPTION
Follow-up to the #47 review (issue #44).

## Problem
`RecyclingGrid::getDefaultFocus()` fell back to the **first focusable child in `contentBox` insertion order**. Cells are appended in *recycle* order, not index order, so once a grid has scrolled the "first child" is an arbitrary (often off-screen) cell rather than the top-left one. A `giveFocus` via a navigation route could therefore land focus on the wrong album/movie.

This is the same *insertion-order ≠ index-order* invariant that the DOWN-into-grid fix in #47 already handled inline.

## Change
- Extract `firstCellFocus()` — the **lowest-index** attached, focusable cell — and use it both in `getDefaultFocus()` and in the DOWN branch of `getNextCellFocus()` (which previously computed the min index with a duplicated inline loop).
- `getDefaultFocus()` keeps the **scrolled-header priority**: the artist page's *Shuffle* button remains the default focus; only the cell fallback changes.

No behavioral change for headerless grids beyond picking the true top-left cell.

## Verification
Desktop build (x86_64) driven against a live Jellyfin server:
- artist page still opens with focus on *Lecture aléatoire* (header priority preserved) ✅
- the #44 down → album → up → Shuffle round trip is intact ✅
- movie library-grid navigation unaffected ✅