### PR TITLE
fix(music): accurate loading skeleton for the album screen

### DIFF
--- a/app/include/view/recycling_grid.hpp
+++ b/app/include/view/recycling_grid.hpp
@@ -266,6 +266,16 @@ public:
     void draw(NVGcontext* vg, float x, float y, float width, float height, brls::Style style,
         brls::FrameContext* ctx) override;
 
+protected:
+    /// Pulsing shimmer gradient anchored to the cell's own draw rect. Shared
+    /// by every skeleton shape — the generic block/card below, and any
+    /// screen-specific skeleton (e.g. the album header/track rows in
+    /// media_music.cpp) — so all loading placeholders animate in sync.
+    NVGpaint shimmerPaint(NVGcontext* vg, float x, float y, float width, float height);
+
+    /// One shimmering rounded-rect bar painted with `shimmerPaint`.
+    static void bar(NVGcontext* vg, NVGpaint paint, float x, float y, float w, float h, float radius);
+
 private:
     NVGcolor background = brls::Application::getTheme()["color/grey_3"];
 };

--- a/app/src/tab/media_music.cpp
+++ b/app/src/tab/media_music.cpp
@@ -12,6 +12,7 @@
 #include "view/video_source.hpp"
 #include "view/music_now_playing.hpp"
 #include "view/icon_button.hpp"
+#include <algorithm>
 
 using namespace brls::literals;  // for _i18n
 
@@ -119,12 +120,97 @@ private:
     std::vector<media::Item> list;
 };
 
+// ---- Album loading skeleton ---------------------------------------------------
+// The generic RecyclingGrid skeleton (uniform full-width blocks, see
+// SkeletonCell::draw) does not resemble this screen's actual layout: a big
+// square cover + a couple of text lines + a button on the first row, then
+// compact track rows. Mirror AlbumHeaderCell/TrackCell's shapes instead so the
+// loading flash reads as "this album is loading", not as a random grid.
+
+/// Header skeleton: cover square (album_header.xml: 225x225, radius 10) +
+/// title/meta bars + a pill-shaped button bar, centered against the cover
+/// like the real header's column (justifyContent="center").
+class AlbumHeaderSkeletonCell : public SkeletonCell {
+public:
+    static RecyclingGridItem* create() { return new AlbumHeaderSkeletonCell(); }
+
+    void draw(NVGcontext* vg, float x, float y, float width, float height, brls::Style style,
+        brls::FrameContext* ctx) override {
+        NVGpaint paint = this->shimmerPaint(vg, x, y, width, height);
+
+        float cover = 225;
+        bar(vg, paint, x, y, cover, cover, 10);
+
+        // right column (marginLeft 24), like album_header.xml
+        float colX = x + cover + 24;
+        float colW = std::max(width - cover - 24, 40.0f);
+
+        float titleH = 24, metaH = 14, btnH = 44;
+        float contentH = titleH + 8 /* labelMeta marginTop */ + metaH + 14 /* button box marginTop */ + btnH;
+        float top = y + (cover - contentH) / 2;
+
+        bar(vg, paint, colX, top, std::min(colW, 400.0f) * 0.55f, titleH, 8);
+        top += titleH + 8;
+        bar(vg, paint, colX, top, std::min(colW, 400.0f) * 0.32f, metaH, 6);
+        top += metaH + 14;
+        bar(vg, paint, colX, top, std::min(colW, 180.0f), btnH, btnH / 2);
+    }
+};
+
+/// Track row skeleton: small square cover (track_row.xml: 46x46, radius 8,
+/// padding 5 -> fills ROW_HEIGHT exactly) + a title bar + a trailing duration
+/// bar, mirroring [cover][title ....][duration].
+class AlbumTrackSkeletonCell : public SkeletonCell {
+public:
+    static RecyclingGridItem* create() { return new AlbumTrackSkeletonCell(); }
+
+    void draw(NVGcontext* vg, float x, float y, float width, float height, brls::Style style,
+        brls::FrameContext* ctx) override {
+        NVGpaint paint = this->shimmerPaint(vg, x, y, width, height);
+
+        float pad = 5, cover = 46;
+        bar(vg, paint, x + pad, y + pad, cover, cover, 8);
+
+        // title bar, past where the index column sits (marginLeft 14 + width 40 + marginLeft 4)
+        float titleX = x + pad + cover + 14 + 40 + 4;
+        float durationW = 40;
+        float durationX = x + width - pad - durationW;
+        float titleW = std::max((durationX - 10 - titleX) * 0.55f, 0.0f);
+        bar(vg, paint, titleX, y + height / 2 - 8, titleW, 16, 6);
+
+        bar(vg, paint, durationX, y + height / 2 - 6, durationW, 12, 5);
+    }
+};
+
+/// Loading placeholder for MediaAlbum: header skeleton + a handful of row
+/// skeletons, same fixed heights as AlbumTracksDataSource so scrolling and
+/// layout behave identically once the real data source replaces this one.
+class AlbumSkeletonDataSource : public RecyclingGridDataSource {
+public:
+    static constexpr size_t ROWS = 8;
+
+    size_t getItemCount() override { return ROWS + 1; }
+
+    float heightForRow(brls::View* recycler, size_t index) override {
+        return index == 0 ? AlbumTracksDataSource::HEADER_HEIGHT : AlbumTracksDataSource::ROW_HEIGHT;
+    }
+
+    RecyclingGridItem* cellForRow(RecyclingView* recycler, size_t index) override {
+        return recycler->dequeueReusableCell(index == 0 ? "HeaderSkeleton" : "RowSkeleton");
+    }
+
+    void clearData() override {}
+};
+
 // ---- MediaAlbum --------------------------------------------------------------
 
 MediaAlbum::MediaAlbum(const media::Item& item) : album(item) {
     this->inflateFromXMLRes("xml/tabs/album.xml");
     this->recycler->registerCell("Header", []() { return new AlbumHeaderCell(); });
     this->recycler->registerCell("Cell", []() { return new TrackCell(); });
+    this->recycler->registerCell("HeaderSkeleton", AlbumHeaderSkeletonCell::create);
+    this->recycler->registerCell("RowSkeleton", AlbumTrackSkeletonCell::create);
+    this->recycler->setDataSource(new AlbumSkeletonDataSource());
     this->doRequest();
 }
 

--- a/app/src/view/recycling_grid.cpp
+++ b/app/src/view/recycling_grid.cpp
@@ -31,8 +31,7 @@ SkeletonCell::SkeletonCell() { this->setFocusable(false); }
 
 RecyclingGridItem* SkeletonCell::create() { return new SkeletonCell(); }
 
-void SkeletonCell::draw(
-    NVGcontext* vg, float x, float y, float width, float height, brls::Style style, brls::FrameContext* ctx) {
+NVGpaint SkeletonCell::shimmerPaint(NVGcontext* vg, float x, float y, float width, float height) {
     brls::Time curTime = brls::getCPUTimeUsec() / 1000;
     float p = (curTime % 1000) * 1.0 / 1000;
     p = std::fabs(0.5 - p) + 0.25;
@@ -40,27 +39,33 @@ void SkeletonCell::draw(
     NVGcolor end = background;
     end.a = p;
 
-    NVGpaint paint = nvgLinearGradient(vg, x, y, x + width, y + height, a(background), a(end));
-    auto bar = [&](float bx, float by, float bw, float bh, float radius) {
-        nvgBeginPath(vg);
-        nvgFillPaint(vg, paint);
-        nvgRoundedRect(vg, bx, by, bw, bh, radius);
-        nvgFill(vg);
-    };
+    return nvgLinearGradient(vg, x, y, x + width, y + height, a(background), a(end));
+}
+
+void SkeletonCell::bar(NVGcontext* vg, NVGpaint paint, float x, float y, float w, float h, float radius) {
+    nvgBeginPath(vg);
+    nvgFillPaint(vg, paint);
+    nvgRoundedRect(vg, x, y, w, h, radius);
+    nvgFill(vg);
+}
+
+void SkeletonCell::draw(
+    NVGcontext* vg, float x, float y, float width, float height, brls::Style style, brls::FrameContext* ctx) {
+    NVGpaint paint = this->shimmerPaint(vg, x, y, width, height);
 
     // small cells (lists, chips): a single block
     if (height < 120) {
-        bar(x, y, width, height, 6);
+        bar(vg, paint, x, y, width, height, 6);
         return;
     }
 
     // structure of a media card: poster + title bar + subtitle
     // (same metrics as video_card.xml: label area = 55)
     float labels = 55;
-    bar(x, y, width, height - labels, 10);
+    bar(vg, paint, x, y, width, height - labels, 10);
     float top = y + height - labels + 12;
-    bar(x + width * 0.15f, top, width * 0.70f, 14, 7);
-    bar(x + width * 0.275f, top + 22, width * 0.45f, 10, 5);
+    bar(vg, paint, x + width * 0.15f, top, width * 0.70f, 14, 7);
+    bar(vg, paint, x + width * 0.275f, top + 22, width * 0.45f, 10, 5);
 }
 
 /// Skeleton DataSource


### PR DESCRIPTION
The album detail screen (Artist → Album) used the generic `RecyclingGrid` skeleton — uniform full-width gray blocks — which looks nothing like the real layout (a large square cover + title/meta + a *Lire l'album* button, then compact track rows). The loading flash read as a random grid rather than "this album is loading".

## Change
- Extract the shimmer paint + rounded-bar helper out of `SkeletonCell::draw` (`shimmerPaint` / `bar`, protected) so screen-specific skeletons reuse the same synced pulse.
- `AlbumHeaderSkeletonCell` / `AlbumTrackSkeletonCell` draw shapes that mirror `album_header.xml` / `track_row.xml`: a header (cover square + title/meta bars + button pill) and track rows (small square + title bar + trailing duration bar).
- `AlbumSkeletonDataSource` lays them out with the **same fixed heights** as `AlbumTracksDataSource` (header 255, rows 56), so layout/scroll behave identically once the real data source replaces it. `MediaAlbum` shows it until `getChildren` resolves.

Backend-agnostic (any album, Plex/Jellyfin/Emby). Single change touching `media_music.cpp` + the `SkeletonCell` helper split.

## Verification
Driven in the background against a live Jellyfin server (no foreground interference — `GMCA_NAV_PIPE` injection + window-id capture):

**Loading (new skeleton)** — cover block, title/meta/button, track rows with cover+title+duration:
```
[▉▉▉▉]  ▬▬▬▬▬▬
        ▬▬▬
        (  ▬▬▬  )
[▪] ▬▬▬▬▬▬▬▬▬▬▬▬        ▬
[▪] ▬▬▬▬▬▬▬▬▬▬▬▬        ▬
```
**Loaded** — real cover, "Think Of Time · Nirvana Motion · 2023 · 2 titres · Lire l'album", tracks 11:07 / 04:38. Skeleton is cleanly replaced by the real tracks; no regression, no crash.

_Originally scaffolded by a background Sonnet agent (interrupted by a session limit); completed, reviewed, built and verified here._