### PR TITLE
fix(connection): actionable DNS error for unresolvable server hostnames (+ Switch threaded resolver)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -108,6 +108,12 @@ jobs:
       image: devkitpro/devkita64:20260219
     env:
       BASE_URL: https://github.com/dragonflylee/switchfin/releases/download/switch-portlibs
+      # curl is rebuilt with --enable-threaded-resolver (scripts/switch/curl) and
+      # hosted on this fork's own switch-portlibs release: the app resolves server
+      # hostnames from background threads, where the synchronous resolver cannot
+      # honor DNS timeouts, so a slow lookup stalls forever. The other packages
+      # stay on the upstream (known-good) release. Mirrors the Vita (see build-psv).
+      CURL_URL: https://github.com/thcolin/gamepad-media-center-aggregator/releases/download/switch-portlibs
     steps:
     - uses: actions/checkout@v6
       with:
@@ -124,9 +130,14 @@ jobs:
     - name: Update dependencies
       run: |
         dkp-pacman --noconfirm -U $BASE_URL/hacBrewPack-3.05-1-x86_64.pkg.tar.zst
-        for pkg in mbedtls-3.6.5-1 libssh2-1.11.1-1 dav1d-1.5.3-1 curl-8.16.0-2 ffmpeg-7.1.5-5 libmpv${{ matrix.shuffix }}-0.36.0-5 nspmini-main-1; do
+        for pkg in mbedtls-3.6.5-1 libssh2-1.11.1-1 dav1d-1.5.3-1 ffmpeg-7.1.5-5 libmpv${{ matrix.shuffix }}-0.36.0-5 nspmini-main-1; do
           dkp-pacman --noconfirm -U $BASE_URL/switch-${pkg}-any.pkg.tar.zst
         done
+        # curl (threaded resolver) from this fork's release; fall back to the
+        # upstream prebuilt until the custom package is published (scripts/switch/curl
+        # + the switch-portlibs workflow). Activates automatically once -3 exists.
+        dkp-pacman --noconfirm -U $CURL_URL/switch-curl-8.16.0-3-any.pkg.tar.zst \
+          || dkp-pacman --noconfirm -U $BASE_URL/switch-curl-8.16.0-2-any.pkg.tar.zst
         git config --system --add safe.directory $GITHUB_WORKSPACE
     - name: Build libusbhsfs
       run: |

--- a/app/include/api/http.hpp
+++ b/app/include/api/http.hpp
@@ -11,6 +11,7 @@
 #include <atomic>
 #include <fstream>
 #include <sstream>
+#include <stdexcept>
 #include <curl/system.h>
 
 #include <borealis/core/event.hpp>
@@ -50,6 +51,25 @@ public:
     };
 
     using Cookies = std::vector<Cookie>;
+
+    /// Coarse category of a failed request, exposed so callers can react to a
+    /// class of failure without depending on <curl/curl.h> error codes. Kept
+    /// deliberately small — only distinctions the UI acts on live here.
+    enum class ErrorKind {
+        Other,          ///< HTTP status >= 400, connect/TLS failure, timeout, proxy resolve, …
+        ResolveFailed,  ///< the server host failed to resolve (curl COULDNT_RESOLVE_HOST)
+    };
+
+    /// Exception thrown by every request path. `what()` carries a
+    /// human-readable message (curl's strerror or an "http status N" string);
+    /// `kind` lets a caller special-case a category — e.g. turn a DNS failure
+    /// into an actionable "use the server's IP address" hint (the consoles have
+    /// no mDNS and are IPv4-only, so .local / IPv6-only hosts never resolve).
+    class Error : public std::runtime_error {
+    public:
+        Error(ErrorKind kind, const std::string& message) : std::runtime_error(message), kind(kind) {}
+        ErrorKind kind;
+    };
 
     HTTP();
     HTTP(const HTTP& other) = delete;

--- a/app/include/utils/hostname.hpp
+++ b/app/include/utils/hostname.hpp
@@ -1,0 +1,46 @@
+/*
+    GMCA — pure URL host helpers (no HTTP / Borealis dependency, so the logic is
+    unit-testable standalone; see tests/test_hostname.cpp). Used by
+    utils/net_error.hpp to name and classify the host a server URL points at.
+*/
+
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+
+namespace net {
+
+/// Host portion of a URL: text between the scheme and the first '/', '?' or
+/// ':', minus any userinfo, with IPv6 brackets stripped. Best-effort — only
+/// used to name the offending host back to the user.
+inline std::string hostFromUrl(const std::string& url) {
+    std::string s = url;
+    auto scheme = s.find("://");
+    if (scheme != std::string::npos) s = s.substr(scheme + 3);
+    s = s.substr(0, s.find_first_of("/?"));  // drop path/query
+    auto at = s.rfind('@');
+    if (at != std::string::npos) s = s.substr(at + 1);  // drop userinfo
+    if (!s.empty() && s.front() == '[') {               // literal IPv6 [::1]:port
+        auto close = s.find(']');
+        return close == std::string::npos ? s.substr(1) : s.substr(1, close - 1);
+    }
+    auto colon = s.rfind(':');
+    if (colon != std::string::npos) s = s.substr(0, colon);  // drop :port
+    return s;
+}
+
+/// True when the host is an mDNS `.local` name — unresolvable on console by
+/// construction, so the add form can warn before even attempting a request.
+/// LAN-only unicast names and IPv6-only hosts also fail, but only at resolve
+/// time; those are caught reactively via HTTP::ErrorKind::ResolveFailed.
+inline bool isMdnsHost(const std::string& url) {
+    std::string host = hostFromUrl(url);
+    std::transform(host.begin(), host.end(), host.begin(), [](unsigned char c) { return std::tolower(c); });
+    if (!host.empty() && host.back() == '.') host.pop_back();  // tolerate a trailing dot
+    const std::string suffix = ".local";
+    return host.size() > suffix.size() && host.compare(host.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+}  // namespace net

--- a/app/include/utils/net_error.hpp
+++ b/app/include/utils/net_error.hpp
@@ -1,0 +1,43 @@
+/*
+    GMCA — user-facing text for server-connection failures.
+
+    A game console can't resolve every hostname a PC can: libnx (Switch) and
+    SceNet (Vita) ship no mDNS responder, so `.local` names never resolve; both
+    stacks are IPv4-only (Switch registers only AF_INET/AF_ROUTE, the Vita's
+    SceNet has no IPv6 at all), so an IPv6-only host never connects; and a Switch
+    pointed at a public DNS (8.8.8.8…) can't see a LAN-only unicast name its
+    router would. All three surface as curl's terse "Couldn't resolve host name".
+
+    Rather than dump that raw, these helpers name the host and tell the user the
+    one thing that always works on console — the server's raw IPv4 address. The
+    pure host parsing lives in utils/hostname.hpp (dependency-free, unit-tested).
+*/
+
+#pragma once
+
+#include "api/http.hpp"
+#include "utils/hostname.hpp"
+
+#include <borealis/core/i18n.hpp>
+#include <fmt/format.h>
+
+#include <string>
+
+namespace net {
+
+/// Actionable guidance for a DNS dead-end: names the host and points the user at
+/// the server's raw IPv4 address (proactive `.local` catch and reactive resolve
+/// failure share it — the advice is the same either way).
+inline std::string dnsHelp(const std::string& url) {
+    using namespace brls::literals;
+    return fmt::format(fmt::runtime("main/server/dns_unresolved"_i18n), hostFromUrl(url));
+}
+
+/// A host DNS resolution failure becomes the IP-address hint; any other failure
+/// (HTTP status, TLS, connect, timeout, and a proxy-resolution failure — which
+/// is about the proxy, not the server URL) passes through unchanged.
+inline std::string errorText(const HTTP::Error& ex, const std::string& url) {
+    return ex.kind == HTTP::ErrorKind::ResolveFailed ? dnsHelp(url) : ex.what();
+}
+
+}  // namespace net

--- a/app/src/api/http.cpp
+++ b/app/src/api/http.cpp
@@ -71,15 +71,20 @@ char __attribute__((optimize("no-optimize-sibling-calls"))) * sce_strdup(const c
 #define CURL_PROGRESSFUNC_CONTINUE 0x10000001
 #endif
 
-class curl_error : public std::exception {
-public:
-    explicit curl_error(CURLcode code) : m(curl_easy_strerror(code)) {}
-    explicit curl_error(const std::string& arg) : m(arg) {}
-    const char* what() const noexcept override { return m.c_str(); }
+/// Map a libcurl result to the coarse HTTP::ErrorKind the UI reacts to. Only a
+/// failure to resolve the *server host* is singled out (see HTTP::Error), since
+/// the hint names that host. CURLE_COULDNT_RESOLVE_PROXY is deliberately left as
+/// Other: it's about the (separate, user-set) proxy address, so it must keep
+/// curl's own "Couldn't resolve proxy name" instead of pointing at the server.
+static HTTP::ErrorKind kindFromCurl(CURLcode code) {
+    if (code == CURLE_COULDNT_RESOLVE_HOST) return HTTP::ErrorKind::ResolveFailed;
+    return HTTP::ErrorKind::Other;
+}
 
-private:
-    std::string m;
-};
+/// A curl-code failure carries the mapped kind; a message-only failure (HTTP
+/// status) is always ErrorKind::Other.
+static HTTP::Error curl_error(CURLcode code) { return HTTP::Error(kindFromCurl(code), curl_easy_strerror(code)); }
+static HTTP::Error curl_error(const std::string& arg) { return HTTP::Error(HTTP::ErrorKind::Other, arg); }
 
 static std::string user_agent =
     fmt::format("{}/{} ({})", AppVersion::getPackageName(), AppVersion::getVersion(), AppVersion::getPlatform());

--- a/app/src/tab/jellyfin_add.cpp
+++ b/app/src/tab/jellyfin_add.cpp
@@ -18,6 +18,7 @@
 #include "activity/main_activity.hpp"
 #include "api/jellyfin/auth.hpp"
 #include "utils/config.hpp"
+#include "utils/net_error.hpp"
 
 using namespace brls::literals;
 
@@ -64,6 +65,13 @@ void JellyfinAdd::submit() {
         return;
     }
 
+    // A .local (mDNS) address can never resolve on Switch/Vita, so warn now
+    // rather than after a request that is guaranteed to fail (net_error.hpp).
+    if (net::isMdnsHost(url)) {
+        this->labelStatus->setText(net::dnsHelp(url));
+        return;
+    }
+
     std::string user = this->cellUser->getValue();
     std::string pass = this->cellPasswd->getValue();
 
@@ -83,6 +91,9 @@ void JellyfinAdd::submit() {
             r = jellyfin::login(url, user, pass);
             r.serverName = name;
             ok = true;
+        } catch (const HTTP::Error& ex) {
+            // DNS failure → actionable "use the server's IP" hint; else raw message.
+            error = net::errorText(ex, url);
         } catch (const std::exception& ex) {
             error = ex.what();
         }

--- a/app/src/tab/remote_add.cpp
+++ b/app/src/tab/remote_add.cpp
@@ -16,6 +16,7 @@
 #include "tab/remote_add.hpp"
 #include "client/client.hpp"
 #include "utils/dialog.hpp"
+#include "utils/net_error.hpp"
 #include <curl/curl.h>
 
 using namespace brls::literals;
@@ -252,6 +253,13 @@ void RemoteAdd::submit() {
         return;
     }
 
+    // A .local (mDNS) host can never resolve on Switch/Vita — warn now instead
+    // of after a request guaranteed to fail (net_error.hpp).
+    if (net::isMdnsHost(r.url)) {
+        Dialog::show(net::dnsHelp(r.url));
+        return;
+    }
+
     this->btnSave->setVisibility(brls::Visibility::GONE);
     this->spinner->setVisibility(brls::Visibility::VISIBLE);
     brls::Application::blockInputs();
@@ -266,6 +274,10 @@ void RemoteAdd::submit() {
             auto client = remote::create(r);
             client->list(r.url);
             ok = true;
+        } catch (const HTTP::Error& ex) {
+            // WebDAV/Apache go through HTTP: a DNS failure gets the "use the
+            // server's IP" hint instead of curl's terse message.
+            error = net::errorText(ex, r.url);
         } catch (const std::exception& ex) {
             error = ex.what();
         }

--- a/resources/i18n/cs/main.json
+++ b/resources/i18n/cs/main.json
@@ -422,6 +422,7 @@
     "choose_type": "Zvolte typ připojení",
     "switch_title": "Připojení",
     "add": "Přidat",
+    "dns_unresolved": "Nelze přeložit „{}“. Na Switch/Vita použij IPv4 adresu svého serveru (např. http://192.168.1.50:8096) — názvy .local (mDNS) a pouze IPv6 nejsou podporovány.",
     "jellyfin": {
       "title_jellyfin": "Přihlásit se do Jellyfin",
       "title_emby": "Přihlásit se do Emby",

--- a/resources/i18n/de/main.json
+++ b/resources/i18n/de/main.json
@@ -422,6 +422,7 @@
     "choose_type": "Wähle deinen Verbindungstyp",
     "switch_title": "Verbindungen",
     "add": "Hinzufügen",
+    "dns_unresolved": "„{}“ kann nicht aufgelöst werden. Auf Switch/Vita die IPv4-Adresse deines Servers verwenden (z. B. http://192.168.1.50:8096) – .local (mDNS) und reine IPv6-Namen werden nicht unterstützt.",
     "jellyfin": {
       "title_jellyfin": "In Jellyfin anmelden",
       "title_emby": "In Emby anmelden",

--- a/resources/i18n/en-US/main.json
+++ b/resources/i18n/en-US/main.json
@@ -417,6 +417,7 @@
     "choose_type": "Choose your connection type",
     "switch_title": "Connections",
     "add": "Add",
+    "dns_unresolved": "Can't resolve \"{}\". On Switch/Vita, use your server’s IPv4 address (e.g. http://192.168.1.50:8096) — .local (mDNS) and IPv6-only names aren’t supported.",
     "jellyfin": {
       "title_jellyfin": "Sign in to Jellyfin",
       "title_emby": "Sign in to Emby",

--- a/resources/i18n/es/main.json
+++ b/resources/i18n/es/main.json
@@ -422,6 +422,7 @@
     "choose_type": "Elige el tipo de conexión",
     "switch_title": "Conexiones",
     "add": "Añadir",
+    "dns_unresolved": "No se puede resolver «{}». En Switch/Vita, usa la dirección IPv4 de tu servidor (p. ej. http://192.168.1.50:8096); los nombres .local (mDNS) y solo IPv6 no son compatibles.",
     "jellyfin": {
       "title_jellyfin": "Inicia sesión en Jellyfin",
       "title_emby": "Inicia sesión en Emby",

--- a/resources/i18n/fr/main.json
+++ b/resources/i18n/fr/main.json
@@ -417,6 +417,7 @@
     "choose_type": "Choisissez le type de connexion",
     "switch_title": "Connexions",
     "add": "Ajouter",
+    "dns_unresolved": "Impossible de résoudre « {} ». Sur Switch/Vita, utilise l’adresse IPv4 de ton serveur (ex. : http://192.168.1.50:8096) — les noms .local (mDNS) et IPv6 uniquement ne sont pas pris en charge.",
     "jellyfin": {
       "title_jellyfin": "Connexion à Jellyfin",
       "title_emby": "Connexion à Emby",

--- a/resources/i18n/ja/main.json
+++ b/resources/i18n/ja/main.json
@@ -422,6 +422,7 @@
     "choose_type": "接続の種類を選択",
     "switch_title": "接続先",
     "add": "追加",
+    "dns_unresolved": "「{}」を解決できません。Switch/Vita ではサーバーの IPv4 アドレスを使用してください（例: http://192.168.1.50:8096）。.local（mDNS）や IPv6 のみの名前には対応していません。",
     "jellyfin": {
       "title_jellyfin": "Jellyfin にサインイン",
       "title_emby": "Emby にサインイン",

--- a/resources/i18n/ko/main.json
+++ b/resources/i18n/ko/main.json
@@ -422,6 +422,7 @@
     "choose_type": "연결 유형을 선택하세요",
     "switch_title": "연결 목록",
     "add": "추가",
+    "dns_unresolved": "\"{}\"을(를) 확인할 수 없습니다. Switch/Vita에서는 서버의 IPv4 주소를 사용하세요(예: http://192.168.1.50:8096). .local(mDNS) 및 IPv6 전용 이름은 지원되지 않습니다.",
     "jellyfin": {
       "title_jellyfin": "Jellyfin에 로그인",
       "title_emby": "Emby에 로그인",

--- a/resources/i18n/pt/main.json
+++ b/resources/i18n/pt/main.json
@@ -422,6 +422,7 @@
     "choose_type": "Escolha o tipo de ligação",
     "switch_title": "Ligações",
     "add": "Adicionar",
+    "dns_unresolved": "Não foi possível resolver “{}”. No Switch/Vita, use o endereço IPv4 do seu servidor (ex.: http://192.168.1.50:8096) — nomes .local (mDNS) e apenas IPv6 não são suportados.",
     "jellyfin": {
       "title_jellyfin": "Iniciar sessão no Jellyfin",
       "title_emby": "Iniciar sessão no Emby",

--- a/resources/i18n/ru/main.json
+++ b/resources/i18n/ru/main.json
@@ -422,6 +422,7 @@
     "choose_type": "Выберите тип подключения",
     "switch_title": "Подключения",
     "add": "Добавить",
+    "dns_unresolved": "Не удаётся разрешить «{}». На Switch/Vita используйте IPv4-адрес сервера (например, http://192.168.1.50:8096) — имена .local (mDNS) и только IPv6 не поддерживаются.",
     "jellyfin": {
       "title_jellyfin": "Вход в Jellyfin",
       "title_emby": "Вход в Emby",

--- a/resources/i18n/tr/main.json
+++ b/resources/i18n/tr/main.json
@@ -422,6 +422,7 @@
     "choose_type": "Bağlantı türünü seçin",
     "switch_title": "Bağlantılar",
     "add": "Ekle",
+    "dns_unresolved": "\"{}\" çözümlenemiyor. Switch/Vita’da sunucunuzun IPv4 adresini kullanın (ör. http://192.168.1.50:8096) — .local (mDNS) ve yalnızca IPv6 adları desteklenmez.",
     "jellyfin": {
       "title_jellyfin": "Jellyfin'e Giriş Yap",
       "title_emby": "Emby'ye Giriş Yap",

--- a/resources/i18n/uk/main.json
+++ b/resources/i18n/uk/main.json
@@ -422,6 +422,7 @@
     "choose_type": "Виберіть тип підключення",
     "switch_title": "Підключення",
     "add": "Додати",
+    "dns_unresolved": "Не вдається розпізнати «{}». На Switch/Vita використовуйте IPv4-адресу сервера (напр. http://192.168.1.50:8096) — імена .local (mDNS) та лише IPv6 не підтримуються.",
     "jellyfin": {
       "title_jellyfin": "Увійти в Jellyfin",
       "title_emby": "Увійти в Emby",

--- a/resources/i18n/vi/main.json
+++ b/resources/i18n/vi/main.json
@@ -422,6 +422,7 @@
     "choose_type": "Chọn loại kết nối",
     "switch_title": "Kết nối",
     "add": "Thêm",
+    "dns_unresolved": "Không thể phân giải “{}”. Trên Switch/Vita, hãy dùng địa chỉ IPv4 của máy chủ (ví dụ: http://192.168.1.50:8096) — tên .local (mDNS) và chỉ IPv6 không được hỗ trợ.",
     "jellyfin": {
       "title_jellyfin": "Đăng nhập vào Jellyfin",
       "title_emby": "Đăng nhập vào Emby",

--- a/resources/i18n/zh-Hans/main.json
+++ b/resources/i18n/zh-Hans/main.json
@@ -422,6 +422,7 @@
     "choose_type": "选择连接类型",
     "switch_title": "连接",
     "add": "添加",
+    "dns_unresolved": "无法解析“{}”。在 Switch/Vita 上，请使用服务器的 IPv4 地址（例如 http://192.168.1.50:8096）——不支持 .local（mDNS）和仅 IPv6 的名称。",
     "jellyfin": {
       "title_jellyfin": "登录 Jellyfin",
       "title_emby": "登录 Emby",

--- a/resources/i18n/zh-Hant/main.json
+++ b/resources/i18n/zh-Hant/main.json
@@ -422,6 +422,7 @@
     "choose_type": "選擇連線類型",
     "switch_title": "連線",
     "add": "新增",
+    "dns_unresolved": "無法解析「{}」。在 Switch/Vita 上，請使用伺服器的 IPv4 位址（例如 http://192.168.1.50:8096）——不支援 .local（mDNS）與僅 IPv6 的名稱。",
     "jellyfin": {
       "title_jellyfin": "登入 Jellyfin",
       "title_emby": "登入 Emby",

--- a/scripts/build-switch.sh
+++ b/scripts/build-switch.sh
@@ -16,6 +16,11 @@ cd "$(dirname "$0")/.."
 DRIVER="${DRIVER:-deko3d}"
 IMAGE="devkitpro/devkita64:20260219"
 BASE_URL="https://github.com/dragonflylee/switchfin/releases/download/switch-portlibs"
+# curl is rebuilt with --enable-threaded-resolver (scripts/switch/curl) and hosted
+# on this fork's own switch-portlibs release: the app resolves server hostnames
+# from background threads, where the synchronous resolver can't honor DNS
+# timeouts, so a slow lookup stalls forever. Other packages stay on upstream.
+CURL_URL="https://github.com/thcolin/gamepad-media-center-aggregator/releases/download/switch-portlibs"
 BUILD_DIR="build_switch_${DRIVER}"
 
 CMAKE_EXTRA=""
@@ -46,9 +51,15 @@ docker run --rm --platform linux/amd64 \
     fi
     dkp-pacman --noconfirm -U $BASE_URL/hacBrewPack-3.05-1-x86_64.pkg.tar.zst
     for pkg in switch-mbedtls-3.6.5-1-any switch-libssh2-1.11.1-1-any switch-dav1d-1.5.3-1-any \
-               switch-curl-8.16.0-2-any switch-ffmpeg-7.1.5-5-any switch-nspmini-main-1-any; do
+               switch-ffmpeg-7.1.5-5-any switch-nspmini-main-1-any; do
         dkp-pacman --noconfirm -U $BASE_URL/\${pkg}.pkg.tar.zst
     done
+    # curl (threaded resolver) from this fork's release; fall back to the upstream
+    # prebuilt until the custom package is published (see scripts/switch/curl +
+    # the switch-portlibs workflow). The threaded resolver activates automatically
+    # once the -3 asset exists; until then the build uses upstream's -2.
+    dkp-pacman --noconfirm -U $CURL_URL/switch-curl-8.16.0-3-any.pkg.tar.zst \
+        || dkp-pacman --noconfirm -U $BASE_URL/switch-curl-8.16.0-2-any.pkg.tar.zst
     dkp-pacman --noconfirm -U $BASE_URL/$LIBMPV_PKG
 
     git clone https://github.com/DarkMatterCore/libusbhsfs.git --depth=1 /tmp/libusbhsfs

--- a/scripts/switch/curl/PKGBUILD
+++ b/scripts/switch/curl/PKGBUILD
@@ -1,8 +1,13 @@
 
 # Maintainer: WinterMute <davem@devkitpro.org>
+#
+# GMCA fork note: this diverges from the upstream devkitPro package by ONE flag
+# — ENABLE_THREADED_RESOLVER (see below). pkgrel is bumped so the built package
+# (switch-curl-8.16.0-3) is distinct from devkitPro's -2, and the build pulls
+# THIS one over the stock prebuilt (mirrors the Vita, scripts/vita/curl).
 pkgname=switch-curl
 pkgver=8.16.0
-pkgrel=2
+pkgrel=3
 pkgdesc='An URL retrieval utility and library'
 arch=('any')
 url="https://curl.se/"
@@ -23,9 +28,22 @@ build() {
 
   autoreconf -fi
 
+  # --enable-threaded-resolver (vs the stock package's --disable-threaded-resolver):
+  # the app runs every request from a background thread (ThreadPool / brls::async),
+  # and sets CURLOPT_NOSIGNAL. With the SYNCHRONOUS resolver, a slow or hung
+  # getaddrinfo() can only be aborted via SIGALRM, which libcurl arms on the main
+  # thread alone — so no CURLOPT_*TIMEOUT bounds a DNS lookup off the main thread
+  # (curl docs: "timeouts cannot be honored during DNS lookups ... work around by
+  # building with c-ares or threaded-resolver"). A slow-to-resolve hostname would
+  # then stall a request indefinitely while a raw LAN IP (no lookup) works — the
+  # same defect fixed on the Vita (scripts/vita/curl). The threaded resolver runs
+  # getaddrinfo in a worker thread the timeout can abandon; c-ares is unusable on
+  # the console (no /etc/resolv.conf). IPv6 stays OFF: the Switch socket service
+  # registers only AF_INET/AF_ROUTE (switchbrew.org/wiki/Sockets_services), so an
+  # AF_INET6 socket can't connect — enabling it only adds failed AAAA attempts.
   ./configure --prefix=$PORTLIBS_PREFIX --host=aarch64-none-elf \
     --disable-shared --enable-static --disable-ipv6 --disable-unix-sockets \
-    --disable-manual --disable-threaded-resolver --disable-progress-meter \
+    --disable-manual --enable-threaded-resolver --disable-progress-meter \
     --without-zstd --without-brotli --without-libpsl --enable-websockets \
     --with-mbedtls --with-default-ssl-backend=mbedtls
   sed -i '/HAVE_SOCKETPAIR/d' lib/curl_config.h

--- a/tests/test_hostname.cpp
+++ b/tests/test_hostname.cpp
@@ -1,0 +1,71 @@
+// Standalone logic test — URL host parsing / mDNS detection (utils/hostname.hpp).
+//
+//   c++ -std=gnu++17 -arch x86_64 -Iapp/include tests/test_hostname.cpp -o /tmp/t && /tmp/t
+//
+// Exercises the PURE helpers behind the "could not resolve hostname" fix: the
+// host we name back to the user, and whether it's a `.local` (mDNS) address the
+// console can never resolve. No HTTP / Borealis dependency.
+
+#include <cstdio>
+#include <utils/hostname.hpp>
+
+using net::hostFromUrl;
+using net::isMdnsHost;
+
+static int failures = 0;
+#define CHECK(cond)                                          \
+    do {                                                     \
+        if (!(cond)) {                                       \
+            printf("FAIL: %s (line %d)\n", #cond, __LINE__); \
+            ++failures;                                      \
+        }                                                    \
+    } while (0)
+
+int main() {
+    // --- hostFromUrl + isMdnsHost, the real-world cases -------------------
+    struct Case {
+        const char* url;
+        const char* host;
+        bool mdns;
+    } cases[] = {
+        {"http://jellyfin.local:8096", "jellyfin.local", true},
+        {"http://raspberrypi.local", "raspberrypi.local", true},
+        {"https://JELLYFIN.LOCAL:8920/", "JELLYFIN.LOCAL", true},  // case-insensitive
+        {"http://media.local.:8096", "media.local.", true},        // trailing dot tolerated
+        {"http://192.168.1.50:8096", "192.168.1.50", false},
+        {"http://homeserver:8096", "homeserver", false},
+        {"https://plex.example.com", "plex.example.com", false},
+        {"http://user:pass@nas.local:5000/path", "nas.local", true},  // userinfo stripped
+        {"http://[fe80::1]:8096/x", "fe80::1", false},                // IPv6 literal
+        {"http://localhost", "localhost", false},                     // bare 'local' != .local
+        {"http://mylocal", "mylocal", false},                         // suffix must be ".local"
+        {"webdav://box.local:80/dav/", "box.local", true},
+    };
+    for (const auto& c : cases) {
+        std::string h = hostFromUrl(c.url);
+        bool m = isMdnsHost(c.url);
+        CHECK(h == c.host);
+        CHECK(m == c.mdns);
+        if (h != c.host || m != c.mdns)
+            printf("  (url=%s) got host=%s mdns=%d, expected host=%s mdns=%d\n", c.url, h.c_str(), m, c.host,
+                   c.mdns);
+    }
+
+    // --- edge cases: must not crash, best-effort output -------------------
+    CHECK(hostFromUrl("") == "");                                  // empty
+    CHECK(isMdnsHost("") == false);
+    CHECK(hostFromUrl("jellyfin.local:8096") == "jellyfin.local");  // scheme-less
+    CHECK(isMdnsHost("jellyfin.local:8096") == true);
+    CHECK(hostFromUrl("http://box.local?q=1") == "box.local");      // query, no path
+    CHECK(isMdnsHost("http://box.local?q=1") == true);
+    CHECK(hostFromUrl("http://[fe80::1%25eth0]:80") == "fe80::1%25eth0");  // IPv6 zone id kept inside []
+    CHECK(isMdnsHost("http://[fe80::1%25eth0]:80") == false);
+    CHECK(hostFromUrl("http://.local") == ".local");                // pathological: bare ".local"
+    CHECK(isMdnsHost("http://.local") == false);                    // size must exceed the suffix
+
+    if (failures == 0)
+        printf("test_hostname: all checks passed\n");
+    else
+        printf("test_hostname: %d FAILED\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Context

User report (Reddit): on Switch, Plex says *"server is unreachable"* and Jellyfin fails with *"could not resolve hostname"*.

- **Plex "unreachable"** is already fixed on `dev` (#43 — parallel connection race + split connect/total timeouts). Ships in the next release; not re-addressed here.
- **Jellyfin "could not resolve hostname"** was **not** covered: the add flow surfaced libcurl's raw `CURLE_COULDNT_RESOLVE_HOST` with no guidance. This PR fixes that.

## What this does

**1. Actionable DNS-resolution error (the reported bug)**
- `HTTP` throws a typed `HTTP::Error` with a coarse `ErrorKind`, so callers can tell a *server-host* DNS failure apart without depending on curl codes. `COULDNT_RESOLVE_PROXY` stays `Other` (it's about the user-set proxy, not the server).
- Jellyfin/Emby + WebDAV/HTTP remote add forms now show a clear message — name the host, tell the user to use the server's **raw IPv4 address** — and catch `.local` (mDNS) up front.
- Pure host parsing split into `utils/hostname.hpp` with a standalone test (`tests/test_hostname.cpp`, 12 real cases + edge cases — compiles & passes).
- New i18n key `server/dns_unresolved` in **all 14 languages**.

**2. Switch curl threaded resolver (latent robustness)**
- The Switch used devkitPro's prebuilt libcurl (`--disable-threaded-resolver`); with `CURLOPT_NOSIGNAL` and requests off the UI thread, no `CURLOPT_*TIMEOUT` can bound a slow `getaddrinfo()`. Now built with `--enable-threaded-resolver` (mirrors the Vita). IPv6 stays **off** — the Switch socket service has no `AF_INET6` (verified: [switchbrew](https://switchbrew.org/wiki/Sockets_services)), the Vita none at all.
- Build/CI pull the custom `switch-curl-8.16.0-3` from this fork's `switch-portlibs` release, **falling back to upstream's `-2` until that package is published** (nothing breaks meanwhile).

## Why no IPv6

Verified the consoles can't do IPv6 at the socket layer (Switch registers only `AF_INET`/`AF_ROUTE`; Vita's SceNet is IPv4-only). Enabling it would only add failed AAAA attempts — the IPv6-only case is handled by the actionable message instead.

## Follow-ups (not blocking)
- Publish `switch-curl-8.16.0-3` (run the `switch-portlibs` workflow) to *activate* the threaded resolver; until then the graceful fallback uses upstream `-2`.
- Reporter to confirm the fix on this PR's build before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)