### PR TITLE
fix(vita): bound GPU texture memory + harden playback (overview/music GPU crashes)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -124,7 +124,8 @@ jobs:
     - name: Update dependencies
       run: |
         dkp-pacman --noconfirm -U $BASE_URL/hacBrewPack-3.05-1-x86_64.pkg.tar.zst
-        for pkg in mbedtls-3.6.5-1 libssh2-1.11.1-1 dav1d-1.5.3-1 curl-8.16.0-2 ffmpeg-7.1.5-5 libmpv${{ matrix.shuffix }}-0.36.0-5 nspmini-main-1; do
+        # mbedtls 3.6.5-1 -> 3.6.7-1: switch-portlibs dropped the 3.6.5 asset too.
+        for pkg in mbedtls-3.6.7-1 libssh2-1.11.1-1 dav1d-1.5.3-1 curl-8.16.0-2 ffmpeg-7.1.5-5 libmpv${{ matrix.shuffix }}-0.36.0-5 nspmini-main-1; do
           dkp-pacman --noconfirm -U $BASE_URL/switch-${pkg}-any.pkg.tar.zst
         done
         git config --system --add safe.directory $GITHUB_WORKSPACE
@@ -213,7 +214,10 @@ jobs:
         # stay on the upstream (known-good) release.
         CURL_URL: https://github.com/thcolin/pleNx/releases/download/vita-packages
       run: |
-        for pkg in mbedtls-3.6.5-1 ffmpeg-n6.0-3 mpv-0.36.0-3; do
+        # mbedtls bumped 3.6.5-1 -> 3.6.7-1: switchfin removed the 3.6.5 asset
+        # from its vita-packages release (only 3.6.7 remains). 3.6.x is ABI-
+        # stable, so the curl/ffmpeg/mpv builds link against it unchanged.
+        for pkg in mbedtls-3.6.7-1 ffmpeg-n6.0-3 mpv-0.36.0-3; do
           wget $BASE_URL/${pkg}-arm.tar.xz
         done
         wget $CURL_URL/curl-8.16.0-3-arm.tar.xz

--- a/app/include/api/stremio/types.hpp
+++ b/app/include/api/stremio/types.hpp
@@ -513,13 +513,16 @@ inline std::vector<StreamOption> parseStreams(const nlohmann::json& j) {
 // structured fields and re-render with our own consistent badges, rather than
 // passing the addon's text through verbatim. (Research: every client does this.)
 
-/// Resolution label from a stream's name+title ("4K"/"1080p"/"720p"/"480p"/
-/// "CAM"/"SD"). CAM-class (cam/ts/telesync/screener) ranks below any resolution.
+/// Resolution label from a stream's name+title ("4K"/"1440p"/"1080p"/"720p"/
+/// "480p"/"CAM"/"SD"). CAM-class (cam/ts/telesync/screener) ranks below any
+/// resolution. 1440p gets its own label so the PSV filter can drop it: an
+/// unlabelled 1440p used to fall through to "SD" and rank ABOVE 1080p on Vita.
 inline std::string qualityLabel(const std::string& text) {
     std::string t = text;
     for (auto& c : t) c = (char)std::tolower((unsigned char)c);
     if (t.find("2160") != std::string::npos || t.find("4k") != std::string::npos || t.find("uhd") != std::string::npos)
         return "4K";
+    if (t.find("1440") != std::string::npos || t.find("2k") != std::string::npos) return "1440p";
     if (t.find("1080") != std::string::npos) return "1080p";
     if (t.find("720") != std::string::npos) return "720p";
     if (t.find("480") != std::string::npos) return "480p";
@@ -531,7 +534,8 @@ inline std::string qualityLabel(const std::string& text) {
 
 /// Sort rank for a resolution label (higher = better; CAM/SD low).
 inline int qualityRank(const std::string& label) {
-    if (label == "4K") return 5;
+    if (label == "4K") return 6;
+    if (label == "1440p") return 5;
     if (label == "1080p") return 4;
     if (label == "720p") return 3;
     if (label == "480p" || label == "SD") return 2;
@@ -548,8 +552,29 @@ inline int qualityRankVita(const std::string& label) {
     if (label == "720p") return 5;
     if (label == "480p" || label == "SD") return 4;
     if (label == "1080p") return 3;  // decodable but heavy -> fallback only
-    if (label == "4K") return 1;     // exceeds the decoder; excluded upstream
+    if (label == "4K" || label == "1440p") return 1;  // exceed the decoder; excluded upstream
     return 2;                        // CAM
+}
+
+/// PS Vita video-codec rank. The Vita ffmpeg build ships NO hevc/av1/vp9/xvid
+/// decoder at all (scripts/vita/ffmpeg/VITABUILD compiles --disable-decoders
+/// plus an H.264-centric allowlist) — such streams cannot play, ever, not even
+/// slowly. An empty label (no codec token in the addon text) is most often
+/// H.264 in the wild, so it stays playable-by-default, below explicit H.264.
+inline int codecRankVita(const std::string& label) {
+    if (label == "H.264") return 2;
+    if (label.empty()) return 1;  // unknown: best effort
+    return 0;                     // HEVC / AV1 / XviD: no decoder on Vita
+}
+
+/// PS Vita audio-codec rank, for DEPRIORITIZATION only (never exclusion: a
+/// stream whose audio the Vita build can't decode — no eac3/dca/truehd/opus in
+/// VITABUILD — still plays video, just silent, and the tokens are less reliable
+/// than video ones). Decodable (AAC/AC3/FLAC/MP3) > unknown > undecodable.
+inline int audioRankVita(const std::string& label) {
+    if (label == "AAC" || label == "AC3" || label == "FLAC" || label == "MP3") return 2;
+    if (label.empty()) return 1;
+    return 0;  // DDP / DTS / TrueHD / Atmos / Opus
 }
 
 /// First "<number> <GB|MB|TB>" found, normalized ("8.4 GB"). Empty if none.
@@ -583,7 +608,8 @@ inline std::string parseSizeLabel(const std::string& text) {
     return num + " " + unit;
 }
 
-/// Normalized video codec ("HEVC"/"AV1"/"H.264") from name+title; empty if none.
+/// Normalized video codec ("HEVC"/"AV1"/"H.264"/"XviD") from name+title; empty
+/// if none. H.264 is tested before XviD: "MPEG-4 AVC" names hit "avc" first.
 inline std::string parseCodecLabel(const std::string& text) {
     std::string t = text;
     for (auto& c : t) c = (char)std::tolower((unsigned char)c);
@@ -594,6 +620,29 @@ inline std::string parseCodecLabel(const std::string& text) {
     if (t.find("x264") != std::string::npos || t.find("h264") != std::string::npos ||
         t.find("h.264") != std::string::npos || t.find("avc") != std::string::npos)
         return "H.264";
+    if (t.find("xvid") != std::string::npos || t.find("divx") != std::string::npos) return "XviD";
+    return "";
+}
+
+/// Normalized audio codec from name+title; empty if none. Ordered so the
+/// Dolby Digital Plus spellings match before plain AC3 ("eac3" contains "ac3").
+inline std::string parseAudioLabel(const std::string& text) {
+    std::string t = text;
+    for (auto& c : t) c = (char)std::tolower((unsigned char)c);
+    if (t.find("truehd") != std::string::npos) return "TrueHD";
+    if (t.find("atmos") != std::string::npos) return "Atmos";
+    if (t.find("eac3") != std::string::npos || t.find("e-ac3") != std::string::npos ||
+        t.find("eac-3") != std::string::npos || t.find("ddp") != std::string::npos ||
+        t.find("dd+") != std::string::npos || t.find("digital plus") != std::string::npos)
+        return "DDP";
+    if (t.find("dts") != std::string::npos) return "DTS";
+    if (t.find("opus") != std::string::npos) return "Opus";
+    if (t.find("flac") != std::string::npos) return "FLAC";
+    if (t.find("aac") != std::string::npos) return "AAC";
+    if (t.find("ac3") != std::string::npos || t.find("ac-3") != std::string::npos ||
+        t.find("dd5.1") != std::string::npos)
+        return "AC3";
+    if (t.find("mp3") != std::string::npos) return "MP3";
     return "";
 }
 
@@ -642,10 +691,13 @@ inline media::Media streamToMedia(const StreamOption& s, const std::string& addo
         p.accessible = true;
         p.exists = true;
         m.parts.push_back(std::move(p));
-        std::string codec = parseCodecLabel(blob);
+        // structured fields, not just display: the PSV stream filter/sort in
+        // resolveAllStreams reads them (codecRankVita / audioRankVita)
+        m.videoCodec = parseCodecLabel(blob);
+        m.audioCodec = parseAudioLabel(blob);
         std::string size = parseSizeLabel(s.title.empty() ? s.name : s.title);
         std::string detail;
-        if (!codec.empty()) detail = codec;
+        if (!m.videoCodec.empty()) detail = m.videoCodec;
         if (!size.empty()) detail += (detail.empty() ? "" : "  ·  ") + size;
         m.detail = detail;
     } else if (!s.infoHash.empty()) {

--- a/app/include/utils/image.hpp
+++ b/app/include/utils/image.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <borealis.hpp>
 #include "api/http.hpp"
 #include "api/backend.hpp"
@@ -30,11 +31,18 @@ public:
         // backend-specific URL building (Plex /photo/:/transcode, Jellyfin /Images...);
         // absolute external paths (cast faces...) are returned unchanged by the backend
         std::string url = AppConfig::instance().backend().imageUrl(path, width, height);
-        if (!url.empty()) with(view, url);
+        // width/height are also forwarded to the decoder: backends that can't
+        // resize server-side (Stremio's absolute Cinemeta/RPDB urls) still get
+        // the artwork downscaled to its display size before the GPU upload, so a
+        // 580x859 RPDB poster becomes a 512² texture instead of a 1024² one — the
+        // Vita GPU-memory exhaustion behind the overview crash (GXM only).
+        if (!url.empty()) with(view, url, width, height);
     }
 
     /// @brief 设置要加载内容的图片组件。此函数需要工作在主线程。
-    static void with(brls::Image* view, const std::string& url);
+    /// width/height (>0) = the intended display size, used on GXM to cap the
+    /// decoded texture to the smallest power-of-two that still covers it.
+    static void with(brls::Image* view, const std::string& url, int width = 0, int height = 0);
 
     /// @brief 取消请求，并清空图片。此函数需要工作在主线程。
     static void cancel(brls::Image* view);
@@ -46,11 +54,13 @@ private:
 
 private:
     std::string url;
-    brls::Image* image;
+    // written by clear() (UI thread) while doRequest (worker) reads it on its
+    // cancel/error paths — atomic so neither side sees a torn pointer
+    std::atomic<brls::Image*> image;
     HTTP::Cancel isCancel;
+    int targetW = 0;  // intended display size (GXM texture cap); 0 = unknown
+    int targetH = 0;
 
-    /// 对象池
-    inline static std::list<Ref> pool;
     inline static std::mutex requestMutex;
     inline static std::unordered_map<brls::Image*, Ref> requests;
 };

--- a/app/src/api/stremio/backend.cpp
+++ b/app/src/api/stremio/backend.cpp
@@ -225,19 +225,33 @@ std::vector<media::Media> resolveAllStreams(
         for (auto& s : streams) all.push_back(streamToMedia(s, a.manifest.name));
     }
 #if defined(__PSV__)
-    // PS Vita: 4K exceeds the hardware H.264 decoder (1080p max) and hard-crashes
-    // the GPU on play (the "blue light of death" users report). Drop every 4K
-    // source outright — better an "unsupported" message than a device freeze.
-    // 1080p is kept but demoted below every <=720p option by qualityRankVita, so
-    // the default pick (index 0) stays smooth while the heavier source remains a
-    // manual fallback. See bug #216 (crash on Vita playback).
+    // PS Vita: >1080p exceeds the hardware H.264 decoder (level 4.x) and
+    // hard-crashes the GPU on play (the "blue light of death" users report),
+    // and the Vita ffmpeg build has NO decoder at all for HEVC/AV1/XviD
+    // (scripts/vita/ffmpeg/VITABUILD) — those streams fail 100% of the time.
+    // Drop them outright — better an "unsupported" message than a device
+    // freeze or a guaranteed playback error. 1080p H.264 is kept but demoted
+    // below every <=720p option by qualityRankVita, so the default pick
+    // (index 0) stays smooth while the heavier source remains a manual
+    // fallback. See bug #216 (crash on Vita playback).
     all.erase(std::remove_if(all.begin(), all.end(),
-                  [](const media::Media& m) { return m.videoResolution == "4K"; }),
+                  [](const media::Media& m) {
+                      return m.videoResolution == "4K" || m.videoResolution == "1440p" ||
+                             (m.playable() && codecRankVita(m.videoCodec) == 0);
+                  }),
         all.end());
 #endif
     std::stable_sort(all.begin(), all.end(), [](const media::Media& x, const media::Media& y) {
         if (x.playable() != y.playable()) return x.playable();  // playable first
 #if defined(__PSV__)
+        // decodable video codec first (H.264 explicit > unknown; the
+        // no-decoder codecs were erased above, this is a safety net), then
+        // decodable audio (an eac3/dts/truehd/opus track plays SILENT on the
+        // Vita ffmpeg build), then quality
+        int cx = codecRankVita(x.videoCodec), cy = codecRankVita(y.videoCodec);
+        if (cx != cy) return cx > cy;
+        int ax = audioRankVita(x.audioCodec), ay = audioRankVita(y.audioCodec);
+        if (ax != ay) return ax > ay;
         int qx = qualityRankVita(x.videoResolution), qy = qualityRankVita(y.videoResolution);
 #else
         int qx = qualityRank(x.videoResolution), qy = qualityRank(y.videoResolution);

--- a/app/src/utils/config.cpp
+++ b/app/src/utils/config.cpp
@@ -451,6 +451,15 @@ bool AppConfig::init() {
         // 初始化纹理缓存数量
 #if defined(__PSV__) || defined(__PS4__)
         brls::TextureCache::instance().cache.setCapacity(1);
+#ifdef __PSV__
+        // The entry-count cap alone (401 effective: setCapacity ADDS
+        // DEFAULT_CAPACITY) lets artwork pin ~100+ MB and starve mpv of
+        // LPDDR/CDRAM. Cap the BYTES too: 48 MB of DXT posters is ~200-400
+        // covers, plenty for browsing, and leaves the video allocations room.
+        // (48, not 64: the music-view crash log peaked near ~54 MB of artwork
+        // before the blue light — the budget must sit safely below that.)
+        brls::TextureCache::instance().cache.setByteCapacity(48 * 1024 * 1024);
+#endif
 #else
         brls::TextureCache::instance().cache.setCapacity(getItem(TEXTURE_CACHE_NUM, 200));
 #endif

--- a/app/src/utils/image.cpp
+++ b/app/src/utils/image.cpp
@@ -132,22 +132,27 @@ Image::Image() : image(nullptr) {
 
 Image::~Image() { brls::Logger::verbose("delete Image {}", fmt::ptr(this)); }
 
-void Image::with(brls::Image* view, const std::string& url) {
+void Image::with(brls::Image* view, const std::string& url, int width, int height) {
     int tex = brls::TextureCache::instance().getCache(url);
     if (tex > 0) {
+        // The cache owns this texture. brls::Image defaults freeTexture to
+        // true, so a view whose FIRST load is a cache hit (common on Stremio:
+        // identical absolute URLs across row cells and detail pages) would
+        // nvgDeleteImage a cached texture from clear()/its destructor and
+        // leave a dead id in the cache — drawn later, that's a GXM fault.
+        view->setFreeTexture(false);
         view->innerSetImage(tex);
         return;
     }
 
-    Ref item;
-    std::lock_guard<std::mutex> lock(requestMutex);
+    // One fresh Image per request. Recycling a pooled object whose previous
+    // doRequest could still be in flight shared url/image/isCancel between two
+    // requests: resetting isCancel here REVOKED the cancellation of the old
+    // transfer, which then finished and cached its pixels under this request's
+    // key (wrong artwork, persistent), while both sides raced on the fields.
+    Ref item = std::make_shared<Image>();
 
-    if (pool.empty()) {
-        item = std::make_shared<Image>();
-    } else {
-        item = pool.front();
-        pool.pop_front();
-    }
+    std::lock_guard<std::mutex> lock(requestMutex);
 
     auto it = requests.insert(std::make_pair(view, item));
     if (!it.second) {
@@ -157,7 +162,8 @@ void Image::with(brls::Image* view, const std::string& url) {
 
     item->image = view;
     item->url = url;
-    item->isCancel->store(false);
+    item->targetW = width;
+    item->targetH = height;
     view->ptrLock();
     // 设置图片组件不处理纹理的销毁，由缓存统一管理纹理销毁
     view->setFreeTexture(false);
@@ -173,8 +179,13 @@ void Image::cancel(brls::Image* view) {
 }
 
 void Image::doRequest(HTTP& s) {
+    // clear() ends in view->ptrUnlock(), and ptrLockCounter is a plain int
+    // only ever touched from the UI thread (Box::removeView, the free queue) —
+    // so the worker-side failure paths must route it through brls::sync, like
+    // the success path does.
     if (this->isCancel->load()) {
-        Image::clear(this->image);
+        auto* imagePtr = this->image.load();
+        brls::sync([imagePtr] { Image::clear(imagePtr); });
         return;
     }
     try {
@@ -198,19 +209,29 @@ void Image::doRequest(HTTP& s) {
         }
 
         bool hasAlpha = isWebp;
+        // exact GPU footprint of the upload, forwarded to the TextureCache
+        // byte capacity; 0 = let addCache estimate (w*h*4)
+        size_t texBytes = 0;
 #ifdef BOREALIS_USE_GXM
         if (imageData) {
-            // Cap artwork at 1024px per side before it becomes a GXM texture.
-            // GXM rounds texture dimensions up to the next power of two, so an
-            // unresized backdrop (Stremio serves full-res Cinemeta art — its
-            // imageUrl can't resize an absolute CDN url the way Plex/Jellyfin do)
-            // at 1920x1080 turns into a 2048x2048 texture (~4 MB in DXT5). A few
-            // of those exhaust the Vita's GPU memory; the allocator then returns
-            // null mid-render and GXM faults — the "GPU crash / blue light" users
-            // hit while browsing and when leaving a media overview. The screen is
-            // 960x544, so 1024 is lossless even full-screen and quarters the
-            // texture. 2x box-averaging keeps the downscale cheap on the CPU.
-            while (imageW > 1024 || imageH > 1024) {
+            // Downscale to the smallest power-of-two texture that still covers the
+            // intended DISPLAY size before the GXM upload. GXM rounds texture
+            // dimensions up to the next power of two, so any source Stremio can't
+            // resize server-side (absolute Cinemeta/RPDB urls) bloats the GPU:
+            // a 1920x1080 backdrop -> 2048² (~4 MB), and — the case that crashed
+            // 1.0.5 — a 580x859 RPDB poster shown at 300px -> a full 1024² texture
+            // (~1 MB) instead of 512². A show page stacks many of these and the
+            // Vita runs out of GPU memory -> GXM fault / blue light. Capping to
+            // the display size (poster 300 -> 512², backdrop 1080 -> 1024², hard
+            // ceiling 1024) keeps each texture minimal while staying crisp on the
+            // 960x544 screen. 2x box-averaging keeps the downscale cheap.
+            int tW = this->targetW, tH = this->targetH;
+            if (tW > 0 && tH == 0) tH = (int)((int64_t)tW * imageH / imageW);  // poster: derive H from ratio
+            if (tH > 0 && tW == 0) tW = (int)((int64_t)tH * imageW / imageH);
+            uint32_t capW = tW > 0 ? MIN(nearest_po2((uint32_t)tW), 1024u) : 1024u;
+            uint32_t capH = tH > 0 ? MIN(nearest_po2((uint32_t)tH), 1024u) : 1024u;
+            while (imageData && (imageW > 1024 || imageH > 1024 ||
+                      (nearest_po2((uint32_t)imageW) > capW && nearest_po2((uint32_t)imageH) > capH))) {
                 int nw, nh;
                 uint8_t* half = halve_rgba(imageData, imageW, imageH, &nw, &nh);
                 if (!half) break;
@@ -242,11 +263,13 @@ void Image::doRequest(HTTP& s) {
             }
             size_t size = nearest_po2(imageW) * nearest_po2(imageH);
             if (!hasAlpha) size >>= 1;
+            // GXM allocates exactly the po2 DXT buffer (4 KB-rounded)
+            texBytes = size;
             // calloc: the compressor skips blocks outside the image, and the
             // whole power-of-two buffer is uploaded to GPU memory — padding
             // must be deterministic zeros, not heap garbage
             auto* compressed = (uint8_t*)calloc(size, 1);
-            dxt_compress(compressed, imageData, imageW, imageH, hasAlpha);
+            if (compressed) dxt_compress(compressed, imageData, imageW, imageH, hasAlpha);
 #ifdef USE_WEBP
             if (isWebp)
                 WebPFree(imageData);
@@ -254,10 +277,12 @@ void Image::doRequest(HTTP& s) {
 #endif
                 stbi_image_free(imageData);
 
+            // compressed == nullptr (RAM exhausted): drop this artwork — the
+            // sync below treats a null imageData as "nothing to upload"
             imageData = compressed;
         }
 #endif
-        auto imagePtr = this->image;
+        auto* imagePtr = this->image.load();
         auto urlCopy = this->url;
         auto isCancelCopy = this->isCancel;
 #ifdef BOREALIS_USE_GXM
@@ -268,14 +293,14 @@ void Image::doRequest(HTTP& s) {
 #endif
 
         brls::Logger::verbose("request Image {} size {}", urlCopy, data.size());
-        brls::sync([imagePtr, urlCopy, isCancelCopy, imageData, imageW, imageH, isWebp, imageFlags] {
+        brls::sync([imagePtr, urlCopy, isCancelCopy, imageData, imageW, imageH, isWebp, imageFlags, texBytes] {
             if (!isCancelCopy->load()) {
                 // Load texture
                 int tex = brls::TextureCache::instance().getCache(urlCopy);
                 if (tex == 0 && imageData != nullptr) {
                     NVGcontext* vg = brls::Application::getNVGContext();
                     tex = nvgCreateImageRGBA(vg, imageW, imageH, imageFlags, imageData);
-                    brls::TextureCache::instance().addCache(urlCopy, tex);
+                    brls::TextureCache::instance().addCache(urlCopy, tex, texBytes);
                 }
                 if (tex > 0) imagePtr->innerSetImage(tex);
                 clear(imagePtr);
@@ -295,7 +320,8 @@ void Image::doRequest(HTTP& s) {
         });
     } catch (const std::exception& ex) {
         brls::Logger::warning("request image {} {}", this->url, ex.what());
-        Image::clear(this->image);
+        auto* imagePtr = this->image.load();
+        brls::sync([imagePtr] { Image::clear(imagePtr); });
     }
 }
 
@@ -305,9 +331,8 @@ void Image::clear(brls::Image* view) {
     auto it = requests.find(view);
     if (it == requests.end()) return;
 
-    it->second->image->ptrUnlock();
+    view->ptrUnlock();
     it->second->image = nullptr;
     it->second->isCancel->store(true);
-    pool.push_back(it->second);
     requests.erase(it);
 }

--- a/app/src/view/mpv_core.cpp
+++ b/app/src/view/mpv_core.cpp
@@ -82,6 +82,11 @@ void MPVCore::on_update(void *self) {
         uint64_t flags = mpv_render_context_update(mpv->mpv_context);
 #if defined(MPV_SW_RENDER) || defined(BOREALIS_USE_GXM)
         if (flags & MPV_RENDER_UPDATE_FRAME) {
+#ifdef BOREALIS_USE_GXM
+            // FBO alloc can fail under GPU-memory pressure (init() leaves
+            // render_target null): skip the render, mpv keeps decoding audio.
+            if (!mpv->mpv_fbo.render_target) return;
+#endif
             mpv_render_context_render(mpv->mpv_context, mpv->mpv_params);
             mpv_render_context_report_swap(mpv->mpv_context);
         }
@@ -271,25 +276,43 @@ void MPVCore::init() {
         int texture_width = DISPLAY_WIDTH;
         int texture_height = DISPLAY_HEIGHT;
         int texture_stride = ALIGN(texture_width, 8);
+        // Every step of this chain allocates GPU memory and the player is
+        // created AFTER browsing already filled LPDDR/CDRAM with artwork, so
+        // each one can fail right here. On failure leave render_target null:
+        // on_update/setFrameSize skip the FBO render (audio keeps playing,
+        // video stays black) instead of handing gxmCreateFramebuffer a NULL
+        // texture and data-aborting.
         nvg_image = nvgCreateImageRGBA(vg, texture_width, texture_height, 0, nullptr);
-        NVGXMtexture *texture = nvgxmImageHandle(vg, nvg_image);
-
-        NVGXMframebufferInitOptions framebufferOpts = {
-            .display_buffer_count = 1,  // Must be 1 for custom FBOs
-            .scenesPerFrame = 1,
-            .render_target = texture,
-            .color_format = SCE_GXM_COLOR_FORMAT_U8U8U8U8_ABGR,
-            .color_surface_type = SCE_GXM_COLOR_SURFACE_LINEAR,
-            .display_width = texture_width,
-            .display_height = texture_height,
-            .display_stride = texture_stride,
-        };
-        NVGXMframebuffer *fbo = gxmCreateFramebuffer(&framebufferOpts);
-        mpv_fbo.render_target = fbo->gxm_render_target;
-        mpv_fbo.color_surface = &fbo->gxm_color_surfaces[0].surface;
-        mpv_fbo.depth_stencil_surface = &fbo->gxm_depth_stencil_surface;
-        mpv_fbo.w = texture_width;
-        mpv_fbo.h = texture_height;
+        NVGXMtexture *texture = nvg_image > 0 ? nvgxmImageHandle(vg, nvg_image) : nullptr;
+        if (texture != nullptr && texture->data != nullptr) {
+            NVGXMframebufferInitOptions framebufferOpts = {
+                .display_buffer_count = 1,  // Must be 1 for custom FBOs
+                .scenesPerFrame = 1,
+                .render_target = texture,
+                .color_format = SCE_GXM_COLOR_FORMAT_U8U8U8U8_ABGR,
+                .color_surface_type = SCE_GXM_COLOR_SURFACE_LINEAR,
+                .display_width = texture_width,
+                .display_height = texture_height,
+                .display_stride = texture_stride,
+            };
+            NVGXMframebuffer *fbo = gxmCreateFramebuffer(&framebufferOpts);
+            if (fbo != nullptr && fbo->gxm_render_target != nullptr) {
+                mpv_fbo.render_target = fbo->gxm_render_target;
+                mpv_fbo.color_surface = &fbo->gxm_color_surfaces[0].surface;
+                mpv_fbo.depth_stencil_surface = &fbo->gxm_depth_stencil_surface;
+                mpv_fbo.w = texture_width;
+                mpv_fbo.h = texture_height;
+            } else if (fbo != nullptr) {
+                gxmDeleteFramebuffer(fbo);
+            }
+        }
+        if (!mpv_fbo.render_target) {
+            if (nvg_image > 0) {
+                nvgDeleteImage(vg, nvg_image);
+                nvg_image = 0;
+            }
+            brls::Logger::error("mpv: GXM FBO allocation failed (GPU memory exhausted), video output disabled");
+        }
     }
 #else
     mpv_opengl_init_params gl_init_params{get_proc_address, nullptr};
@@ -454,6 +477,8 @@ void MPVCore::setFrameSize(brls::Rect area) {
     // but mpvRenderContextRender(...) will call functions similar to beginFrame() and endFrame() to draw content to FBO,
     // and that will cause error in GXM, so call in brls::sync to make the mpv drawing calls outside the brls::Application::frame().
     brls::sync([this]() {
+        // no FBO (GPU OOM at init): nothing to render into
+        if (!this->mpv_fbo.render_target) return;
         mpv_render_context_render(this->mpv_context, mpv_params);
         mpv_render_context_report_swap(this->mpv_context);
     });
@@ -494,6 +519,10 @@ void MPVCore::draw(brls::Rect area, float alpha) {
     nvgFillPaint(vg, nvgImagePattern(vg, 0, 0, rect.getWidth(), rect.getHeight(), 0, nvg_image, alpha));
     nvgFill(vg);
 #elif defined(BOREALIS_USE_GXM)
+    // FBO init failed (GPU OOM): nothing to draw. Today nvg_image == 0 would
+    // fall back to the 1x1 dummy texture deep in nanovg_gxm, but don't rely
+    // on that implicit guarantee.
+    if (!mpv_fbo.render_target) return;
     NVGcontext *vg = brls::Application::getNVGContext();
     NVGpaint img =
         nvgImagePattern(vg, area.getMinX(), area.getMinY(), area.getWidth(), area.getHeight(), 0, nvg_image, alpha);

--- a/scripts/patches/borealis-fixes.patch
+++ b/scripts/patches/borealis-fixes.patch
@@ -15,6 +15,127 @@ index 31713045..d8223c0c 100644
      static void addToWatchedKeys(const BrlsKeyCombination key);
  
      static void removeWatchedKeys(const BrlsKeyCombination key);
+diff --git a/library/include/borealis/core/cache_helper.hpp b/library/include/borealis/core/cache_helper.hpp
+index 0236dfed..8dbc8159 100644
+--- a/library/include/borealis/core/cache_helper.hpp
++++ b/library/include/borealis/core/cache_helper.hpp
+@@ -35,9 +35,15 @@ struct Node
+     /// Reference count, 1 for each cache hit
+     size_t count = 1;
+ 
+-    Node(K k, T v)
++    /// Memory the cached value pins (GPU texture bytes); 0 when unknown.
++    /// Feeds the LRUCache byte capacity — capping only the ENTRY COUNT lets
++    /// a few hundred posters exhaust the PS Vita's GPU memory.
++    size_t bytes = 0;
++
++    Node(K k, T v, size_t b = 0)
+         : key(k)
+         , value(v)
++        , bytes(b)
+     {
+     }
+ };
+@@ -80,20 +86,30 @@ class LRUCache
+         return cacheMap[key]->value;
+     }
+ 
+-    void set(K key, T value)
++    void set(K key, T value, size_t bytes = 0)
+     {
+         if (isCacheHit(key))
+         {
+             throw std::logic_error("Can not cache the same key twice.");
+         }
+ 
+-        // Check capacity limits
++        // Check capacity limits (+1: make room for the entry being added,
++        // otherwise the cache stabilizes one entry above its capacity)
+         if (cacheList.size() >= capacity)
+         {
+-            deleteCache(cacheList.size() - capacity);
++            deleteCache(cacheList.size() - capacity + 1);
++        }
++        // Byte capacity: evict LRU unreferenced entries until the new entry
++        // fits. deleteCache returns non-zero when nothing more is evictable
++        // (every remaining entry is pinned) — stop there rather than loop.
++        while (byteCapacity != 0 && totalBytes + bytes > byteCapacity && !cacheList.empty())
++        {
++            if (deleteCache(1) != 0)
++                break;
+         }
+         // Add new cache
+-        cacheList.push_front(Node<K, T>(key, value));
++        totalBytes += bytes;
++        cacheList.push_front(Node<K, T>(key, value, bytes));
+ 
+         // Update the values of two maps
+         cacheMap[key]                  = cacheList.begin();
+@@ -139,6 +155,21 @@ class LRUCache
+         }
+     }
+ 
++    /// Cap the total bytes pinned by cached values (0 = unlimited). Entries
++    /// added with bytes=0 never count toward the cap (their size is unknown)
++    /// but remain evictable like any other LRU entry.
++    void setByteCapacity(size_t bytes)
++    {
++        this->byteCapacity = bytes;
++        while (byteCapacity != 0 && totalBytes > byteCapacity && !cacheList.empty())
++        {
++            if (deleteCache(1) != 0)
++                break;
++        }
++    }
++
++    size_t bytesUsed() const { return totalBytes; }
++
+     /**
+      * A dirty cache is not able to be hit
+      * @param value
+@@ -186,6 +217,8 @@ class LRUCache
+ 
+   private:
+     size_t capacity = 1;
++    size_t byteCapacity = 0;  // 0 = unlimited
++    size_t totalBytes   = 0;
+     T defaultValue;
+     std::list<Node<K, T>> cacheList;
+     std::unordered_map<K, CacheIter> cacheMap;
+@@ -209,6 +242,7 @@ class LRUCache
+             if (i->count <= 0)
+             {
+                 num--;
++                totalBytes -= i->bytes;
+                 nvgDeleteImage(vg, i->value);
+                 cacheMap.erase(i->key);
+                 valueMap.erase(i->value);
+@@ -248,13 +282,22 @@ class TextureCache : public Singleton<TextureCache>
+     int getCache(const std::string& key) { return cache.get(key); }
+ 
+     /**
+-     * Add cache
++     * Add cache. `bytes` = memory the texture pins (feeds the byte capacity);
++     * when 0 it is estimated as w*h*4 from the texture itself — callers that
++     * know the real footprint (compressed uploads) should pass it.
+      */
+-    void addCache(const std::string& key, size_t texture)
++    void addCache(const std::string& key, size_t texture, size_t bytes = 0)
+     {
+         if (texture <= 0)
+             return;
+-        cache.set(key, texture);
++        if (bytes == 0)
++        {
++            int w = 0, h = 0;
++            nvgImageSize(brls::Application::getNVGContext(), (int)texture, &w, &h);
++            if (w > 0 && h > 0)
++                bytes = (size_t)w * h * 4;
++        }
++        cache.set(key, texture, bytes);
+     }
+ 
+     /**
 diff --git a/library/include/borealis/core/notification_manager.hpp b/library/include/borealis/core/notification_manager.hpp
 index 6f92431b..024a5dfe 100644
 --- a/library/include/borealis/core/notification_manager.hpp
@@ -97,6 +218,85 @@ index 227cd789..a651c841 100644
      /**
        * Called by frame() to draw the view onscreen.
        * Views should not draw outside of their bounds (they
+diff --git a/library/include/borealis/extern/nanovg/nanovg_gxm.h b/library/include/borealis/extern/nanovg/nanovg_gxm.h
+index 8bb4ff7b..ea4d9b7b 100644
+--- a/library/include/borealis/extern/nanovg/nanovg_gxm.h
++++ b/library/include/borealis/extern/nanovg/nanovg_gxm.h
+@@ -312,6 +312,10 @@ static GXMNVGtexture *gxmnvg__allocTexture(GXMNVGcontext *gxm) {
+ 
+ static GXMNVGtexture *gxmnvg__findTexture(GXMNVGcontext *gxm, int id) {
+     int i;
++    // id 0 means "no image"; without this guard it would match any slot the
++    // garbage collector memset to zero and hand out a dead texture.
++    if (id == 0)
++        return NULL;
+     for (i = 0; i < gxm->ntextures; i++)
+         if (gxm->textures[i].id == id)
+             return &gxm->textures[i];
+@@ -1448,9 +1452,14 @@ static void gxmnvg__convexFillStencil(GXMNVGcontext *gxm, GXMNVGcall *call) {
+     // Disable color output
+     gxmnvg__setFragmentProgram(gxm, gxm->depth_texture_shader.prog.frag);
+ 
+-    // Set texture
++    // Set texture. Fall back to the dummy texture (same idiom as
++    // gxmnvg__setUniforms) when the image is 0 or was deleted and collected —
++    // dereferencing the missing texture here was a GPU fault.
+     tex = gxmnvg__findTexture(gxm, call->image);
+-    sceGxmSetFragmentTexture(gxm->context, 0, &tex->texture.tex);
++    if (tex == NULL)
++        tex = gxmnvg__findTexture(gxm, gxm->dummyTex);
++    if (tex != NULL)
++        sceGxmSetFragmentTexture(gxm->context, 0, &tex->texture.tex);
+ 
+     for (i = 0; i < npaths; i++) {
+         for(int j = 0; j < paths[i].fillCount; j++) {
+@@ -2040,7 +2049,9 @@ int nvgxmCreateImageFromHandle(NVGcontext *ctx, SceGxmTexture *texture) {
+ NVGXMtexture *nvgxmImageHandle(NVGcontext *ctx, int image) {
+     GXMNVGcontext *gxm = (GXMNVGcontext *) nvgInternalParams(ctx)->userPtr;
+     GXMNVGtexture *tex = gxmnvg__findTexture(gxm, image);
+-    return &tex->texture;
++    // image 0 (failed nvgCreateImage*) or a deleted texture: let the caller
++    // handle the failure instead of returning a pointer into NULL.
++    return tex ? &tex->texture : NULL;
+ }
+ 
+ #endif /* NANOVG_GL_IMPLEMENTATION */
+diff --git a/library/include/borealis/extern/nanovg/nanovg_gxm_utils.h b/library/include/borealis/extern/nanovg/nanovg_gxm_utils.h
+index 28a06ed6..f2345010 100644
+--- a/library/include/borealis/extern/nanovg/nanovg_gxm_utils.h
++++ b/library/include/borealis/extern/nanovg/nanovg_gxm_utils.h
+@@ -794,7 +794,20 @@ NVGXMframebuffer *gxmCreateFramebuffer(const NVGXMframebufferInitOptions *opts)
+     render_target_params.multisampleLocations = 0;
+     render_target_params.driverMemBlock = -1;
+ 
+-    sceGxmCreateRenderTarget(&render_target_params, &fb->gxm_render_target);
++    // Fails under GPU-memory pressure (out of render targets / driver memory);
++    // unchecked, the NULL target used to reach sceGxmBeginScene and fault there.
++    if (sceGxmCreateRenderTarget(&render_target_params, &fb->gxm_render_target) != 0 ||
++        fb->gxm_render_target == NULL) {
++        gxmDeleteFramebuffer(fb);
++        return NULL;
++    }
++
++    // A custom render target whose texture allocation already failed has no
++    // backing memory: bail out before the memset below writes to NULL.
++    if (opts->render_target && opts->render_target->data == NULL) {
++        gxmDeleteFramebuffer(fb);
++        return NULL;
++    }
+ 
+     fb->gxm_color_surfaces = (NVGXMcolorSurface *) malloc(opts->display_buffer_count * sizeof(NVGXMcolorSurface));
+     if (fb->gxm_color_surfaces == NULL) {
+@@ -882,7 +895,8 @@ void gxmDeleteFramebuffer(NVGXMframebuffer *fb) {
+         free(fb->gxm_color_surfaces);
+     }
+ 
+-    sceGxmDestroyRenderTarget(fb->gxm_render_target);
++    if (fb->gxm_render_target)
++        sceGxmDestroyRenderTarget(fb->gxm_render_target);
+ 
+     free(fb);
+ }
 diff --git a/library/include/borealis/views/bottom_bar.hpp b/library/include/borealis/views/bottom_bar.hpp
 index 17a93796..21ff14e9 100644
 --- a/library/include/borealis/views/bottom_bar.hpp


### PR DESCRIPTION
## Problem
PS Vita users hit "GPU crash / blue light of death" with GMCA — opening a movie/show overview, browsing, and especially the **music library / artist page**. Diagnosed on real hardware via a temporary debug build (forced file log through `Logger::getLogEvent`, since `setLogOutput` is ignored on GXM) — logs pinned the exact operations.

## Root causes (all GXM/LPDDR memory exhaustion)
1. **Oversized artwork textures.** Stremio serves absolute Cinemeta/RPDB URLs that `imageUrl()` can't resize server-side; GXM rounds texture dims up to the next power of two, so a 580×859 RPDB poster shown at ~300px became a **1024²** texture (~1 MB) instead of 512².
2. **Too many textures (music view).** ~200+ album thumbs piled up across navigation (log peaked ~54 MB, tex id 276). The LRU only bounded the **entry count** (401), never the bytes — recycling releases them (`count--`) but `count==0 ≠ evicted`.
3. **Play-time crashes.** The mpv GXM FBO init chain dereferenced results with no null check (crash instead of graceful fail under memory pressure); and Stremio direct-play fed HEVC/AV1/>1080p sources to a decoder that's H.264 ≤1080p only.

## Fix
- **`image.cpp`/`image.hpp`** — downscale artwork to the requested **display size** before the GXM upload (poster → 512², backdrop 1080 → 1024², hard 1024 ceiling fallback).
- **`config.cpp` + borealis patch** — add a **byte budget** to the texture cache and cap it at **48 MB** on Vita (evicts `count==0` textures once exceeded; visible cells never approach it). Patch also null-checks the GXM allocation paths.
- **`mpv_core.cpp`** — guard the FBO init chain; bail cleanly on allocation failure.
- **`stremio/*`** — drop undecodable sources (HEVC/AV1, >1080p) and deprioritize silent-audio ones so the default pick is always decodable.
- **`build.yaml`** — bump `mbedtls` 3.6.5-1 → 3.6.7-1 (upstream removed 3.6.5; the Vita CI was failing at download).

## Validation
- Full **vitasdk cross-build** (`-DPLATFORM_PSV=ON -DUSE_GXM=ON`) — compiles, VPK produced.
- **On-device**: tester confirmed overview + playback (even 4K60 at a lower bitrate) work, and after the byte-cap the **music library/artist page no longer crashes** ("works great").

Debug/logging changes stayed on the throwaway `debug/vita-gpu-overview` branch and are **not** part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)