### PR TITLE
fix(vita): downscale offline/cached artwork on GXM (stop the GPU-memory crash offline)

### DIFF
--- a/app/include/utils/image.hpp
+++ b/app/include/utils/image.hpp
@@ -25,7 +25,19 @@ public:
         // and gives downloaded content instant local artwork even online
         // (SPEC §4.2, AC6/AC17). Keyed by the raw path/url passed here.
         if (ImageCache::has(path)) {
-            view->setImageFromFile(ImageCache::localPath(path));
+            std::string local = ImageCache::localPath(path);
+#ifdef BOREALIS_USE_GXM
+            // GXM: run the cached asset through the same decode+downscale+DXT as
+            // the network path (withLocal -> doRequest). setImageFromFile would
+            // upload it at NATIVE resolution, uncompressed — a downloaded
+            // 2000x3000 poster becomes a ~23 MB RGBA texture (vs ~256 KB DXT1
+            // here), reintroducing the GPU-memory exhaustion the network
+            // downscale fixed, on the offline/downloaded path. width/height cap
+            // the texture to the display size.
+            withLocal(view, local, width, height);
+#else
+            view->setImageFromFile(local);
+#endif
             return;
         }
         // backend-specific URL building (Plex /photo/:/transcode, Jellyfin /Images...);
@@ -44,6 +56,14 @@ public:
     /// decoded texture to the smallest power-of-two that still covers it.
     static void with(brls::Image* view, const std::string& url, int width = 0, int height = 0);
 
+#ifdef BOREALIS_USE_GXM
+    /// GXM offline path: like with(), but reads the pixels from a locally cached
+    /// file instead of the network, then runs the same decode+downscale+DXT as
+    /// doRequest. Keeps a cached native-resolution asset from becoming an
+    /// oversized uncompressed GPU texture (see Image::load). Main thread.
+    static void withLocal(brls::Image* view, const std::string& localPath, int width = 0, int height = 0);
+#endif
+
     /// @brief 取消请求，并清空图片。此函数需要工作在主线程。
     static void cancel(brls::Image* view);
 
@@ -60,6 +80,9 @@ private:
     HTTP::Cancel isCancel;
     int targetW = 0;  // intended display size (GXM texture cap); 0 = unknown
     int targetH = 0;
+    // true (GXM offline): `url` is a local cache file read from disk instead of
+    // fetched over HTTP; the decode/downscale/upload path is otherwise shared.
+    bool local = false;
 
     inline static std::mutex requestMutex;
     inline static std::unordered_map<brls::Image*, Ref> requests;

--- a/app/src/tab/download_tab.cpp
+++ b/app/src/tab/download_tab.cpp
@@ -9,6 +9,7 @@
 #include "view/presenter.hpp"
 #include "utils/config.hpp"
 #include "utils/dialog.hpp"
+#include "utils/image.hpp"
 #include "utils/misc.hpp"
 
 #include <algorithm>
@@ -227,13 +228,33 @@ public:
         this->progressTrack->addView(this->progressBar);
     }
 
+    // The thumb load is async on GXM (withLocal): drop any in-flight request
+    // and reset to the placeholder before this cell is reused for another row,
+    // else a late completion would paint the previous item's poster. Matches
+    // the media grid cells (media_series/media_movie).
+    void prepareForReuse() override { this->thumb->setImageFromRes("img/video-card-bg.png"); }
+    void cacheForReuse() override {
+#ifdef BOREALIS_USE_GXM
+        Image::cancel(this->thumb);
+#endif
+    }
+
     void setItem(const DownloadItem& item, const std::string& downloadDir) {
         auto theme = brls::Application::getTheme();
 
         this->thumb->setImageFromRes("img/video-card-bg.png");
         std::string thumbPath = downloadDir + "/" + item.itemId + "/thumb.png";
         if (fs::exists(thumbPath)) {
+#ifdef BOREALIS_USE_GXM
+            // GXM: decode+downscale+DXT to the 76x114 card size instead of
+            // uploading thumb.png at its native resolution, uncompressed. The
+            // thumbnail is fetched with no resize (download.cpp) so it can be a
+            // full-size poster — the same GPU-memory concern as Image::load.
+            // withLocal is async, so cancel on reuse (cacheForReuse below).
+            Image::withLocal(this->thumb, thumbPath, 76, 114);
+#else
             this->thumb->setImageFromFile(thumbPath);
+#endif
         }
 
         // title = episode or movie name; subtitle = "Show · SxEy" or year,

--- a/app/src/utils/image.cpp
+++ b/app/src/utils/image.cpp
@@ -1,5 +1,6 @@
 #include "utils/image.hpp"
 #include "utils/thread.hpp"
+#include <fstream>
 #include <fmt/format.h>
 #include <borealis/core/cache_helper.hpp>
 #ifdef USE_WEBP
@@ -171,6 +172,39 @@ void Image::with(brls::Image* view, const std::string& url, int width, int heigh
     ThreadPool::instance().submit([item](HTTP& s) { item->doRequest(s); });
 }
 
+#ifdef BOREALIS_USE_GXM
+void Image::withLocal(brls::Image* view, const std::string& localPath, int width, int height) {
+    // Mirrors with(): the cache is keyed by the local path (as setImageFromFile
+    // did), so repeat loads of a cached asset hit the TextureCache directly.
+    int tex = brls::TextureCache::instance().getCache(localPath);
+    if (tex > 0) {
+        view->setFreeTexture(false);
+        view->innerSetImage(tex);
+        return;
+    }
+
+    Ref item = std::make_shared<Image>();
+
+    std::lock_guard<std::mutex> lock(requestMutex);
+
+    auto it = requests.insert(std::make_pair(view, item));
+    if (!it.second) {
+        brls::Logger::warning("insert Image {} failed", fmt::ptr(view));
+        return;
+    }
+
+    item->image = view;
+    item->url = localPath;  // doubles as the disk path (this->local == true)
+    item->local = true;
+    item->targetW = width;
+    item->targetH = height;
+    view->ptrLock();
+    view->setFreeTexture(false);
+
+    ThreadPool::instance().submit([item](HTTP& s) { item->doRequest(s); });
+}
+#endif
+
 void Image::cancel(brls::Image* view) {
     brls::TextureCache::instance().removeCache(view->getTexture());
     view->clear();
@@ -189,16 +223,33 @@ void Image::doRequest(HTTP& s) {
         return;
     }
     try {
-        std::ostringstream body;
-        HTTP::set_option(s, this->isCancel, HTTP::Timeout{});
-        s._get(this->url, &body);
-        std::string data = body.str();
+        std::string data;
+        if (this->local) {
+            // offline: read the cached asset straight off disk — no server, no
+            // curl handle touched (getinfo below would deref a NULL type on it).
+            std::ifstream f(this->url, std::ios::binary);
+            std::ostringstream body;
+            body << f.rdbuf();
+            data = body.str();
+            if (data.empty()) throw std::runtime_error("empty or unreadable cache file");
+        } else {
+            std::ostringstream body;
+            HTTP::set_option(s, this->isCancel, HTTP::Timeout{});
+            s._get(this->url, &body);
+            data = body.str();
+        }
         uint8_t* imageData = nullptr;
         int imageW = 0, imageH = 0;
         bool isWebp = false;
 #ifdef USE_WEBP
+        // Prefer the RIFF....WEBP magic: the only reliable signal for a cached
+        // file (its name is a hash) and for any response with no Content-Type.
+        // The "Webp" URL hint / Content-Type only exist on the network path.
         char* ct = nullptr;
-        if (url.find("Webp") != std::string::npos || (s.getinfo(&ct) && strcmp(ct, "image/webp") == 0)) {
+        bool webpMagic = data.size() >= 12 && memcmp(data.data(), "RIFF", 4) == 0 &&
+                         memcmp(data.data() + 8, "WEBP", 4) == 0;
+        if (webpMagic || url.find("Webp") != std::string::npos ||
+            (!this->local && s.getinfo(&ct) && ct != nullptr && strcmp(ct, "image/webp") == 0)) {
             imageData = WebPDecodeRGBA((const uint8_t*)data.c_str(), data.size(), &imageW, &imageH);
             isWebp = true;
         } else


### PR DESCRIPTION
## Problème

Le downscale d'artwork GXM ajouté en #58 vit **uniquement** dans le chemin **réseau** (`Image::with` → `Image::doRequest`). `Image::load` (`app/include/utils/image.hpp`) le court-circuitait dès qu'un asset était en cache disque :

```cpp
if (ImageCache::has(path)) {
    view->setImageFromFile(ImageCache::localPath(path));  // <- décode + upload NATIF, non compressé
    return;
}
```

`brls::Image::setImageFromFile` → `nvgCreateImage` → `gxmnvg__renderCreateTexture` avec `imageFlags=0` : pas de flag DXT → `swizzled=false` → `tex_size = ALIGN(w,8) * h * 4` (RGBA8 pleine résolution native, aucun power-of-two, aucune compression). Donc **sur du contenu téléchargé / hors-ligne, le crash mémoire GPU que #58 a corrigé revient**.

### Mesures (test C++ autonome, formules répliquées de `image.cpp` et `nanovg_gxm.h`)

| artwork (natif → affichage) | réseau (DXT) | offline (natif, non compressé) | ratio |
|---|---|---|---|
| poster 2000×3000 @325 | 256 Ko | **23,4 Mo** | ×91,6 |
| backdrop 3840×2160 @1080 | 512 Ko | **31,6 Mo** | ×63,3 |
| cover musique 1200×1200 @225 | 32 Ko | **5,6 Mo** | ×175,8 |

Une grille de ~7 artworks typiques : **1,7 Mo en réseau vs 76 Mo en offline**. Le byte-cap de 48 Mo du `TextureCache` est dépassé par ~2 items, et chaque upload est une allocation GPU de plusieurs Mo → exhaustion → GXM fault.

## Correctif (GXM uniquement)

Router le chemin offline par le **même** pipeline décode + downscale 2× box + DXT1/DXT5 que `doRequest`, via un nouveau `Image::withLocal` qui lit le fichier caché sur disque au lieu du réseau.

- Le cache **disque** reste intact (pleine qualité, réutilisable à n'importe quelle taille) ; seule la texture GPU est plafonnée à la taille d'affichage.
- Les autres plateformes gardent `setImageFromFile` (le downscale est GXM-only).
- Le cache-hit du `TextureCache` est inchangé.

Aussi :
- `doRequest` détecte désormais la signature `RIFF....WEBP` → un WebP caché se décode (son nom de fichier est un hash, les indices « Webp »/Content-Type n'existent pas en offline) et garde `s.getinfo()`/`strcmp` contre le handle curl inutilisé du chemin local (déréf NULL évité).
- Les vignettes de `download_tab` (`thumb.png`, téléchargé **sans resize** → potentiellement un poster pleine taille, affiché en 76×114) passent aussi par `withLocal`, avec les hooks `cacheForReuse`/`prepareForReuse` (comme les cellules de la grille média) pour que le chargement désormais async soit sûr au recyclage.

## Vérifications

- Cross-build Vita (Docker `vitasdk/vitasdk`, `-DPLATFORM_PSV=ON -DUSE_GXM=ON`) : **compile**.
- Test numérique sous AddressSanitizer/UBSan pour les tailles.
- **Non vérifié sur matériel** (pas de Vita) : le rendu visuel offline et l'absence de crash en navigation offline réelle restent à confirmer par un testeur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
