### PR TITLE
fix(vita): drop MSAA on the mpv video FBO (free ~6 MB CDRAM during playback)

### DIFF
--- a/app/src/view/mpv_core.cpp
+++ b/app/src/view/mpv_core.cpp
@@ -264,7 +264,14 @@ void MPVCore::init() {
         .context = gxm->context,
         .shader_patcher = gxm->shader_patcher,
         .buffer_index = 0,
-        .msaa = SCE_GXM_MULTISAMPLE_4X,
+        // The video FBO is a fullscreen quad — MSAA antialiases geometry edges,
+        // of which it has none, so 4X only wastes CDRAM. NONE here must match
+        // the FBO's render target (framebufferOpts.msaa below): it drops the
+        // FBO depth/stencil surface from ~8 MB to ~2 MB (960x544), ~6 MB of
+        // CDRAM freed exactly during playback, where GPU memory is tightest and
+        // the FBO alloc already fails first under pressure. The window UI keeps
+        // its own MSAA (nanovg has edgeAntiAlias off, so that AA is load-bearing).
+        .msaa = SCE_GXM_MULTISAMPLE_NONE,
     };
     mpv_render_param params[] = {
         {MPV_RENDER_PARAM_API_TYPE, const_cast<char *>(MPV_RENDER_API_TYPE_GXM)},
@@ -294,6 +301,9 @@ void MPVCore::init() {
                 .display_width = texture_width,
                 .display_height = texture_height,
                 .display_stride = texture_stride,
+                // No MSAA for the video FBO (must match gxm_params.msaa above):
+                // saves ~6 MB CDRAM on its depth/stencil, no visual cost.
+                .msaa = SCE_GXM_MULTISAMPLE_NONE,
             };
             NVGXMframebuffer *fbo = gxmCreateFramebuffer(&framebufferOpts);
             if (fbo != nullptr && fbo->gxm_render_target != nullptr) {

--- a/scripts/patches/borealis-fixes.patch
+++ b/scripts/patches/borealis-fixes.patch
@@ -262,10 +262,42 @@ index 8bb4ff7b..ea4d9b7b 100644
  
  #endif /* NANOVG_GL_IMPLEMENTATION */
 diff --git a/library/include/borealis/extern/nanovg/nanovg_gxm_utils.h b/library/include/borealis/extern/nanovg/nanovg_gxm_utils.h
-index 28a06ed6..f2345010 100644
+index 28a06ed6..f2dc2bbc 100644
 --- a/library/include/borealis/extern/nanovg/nanovg_gxm_utils.h
 +++ b/library/include/borealis/extern/nanovg/nanovg_gxm_utils.h
-@@ -794,7 +794,20 @@ NVGXMframebuffer *gxmCreateFramebuffer(const NVGXMframebufferInitOptions *opts)
+@@ -101,6 +101,16 @@ struct NVGXMframebufferInitOptions {
+     int display_width;
+     int display_height;
+     int display_stride;
++
++    /**
++     * Multisample mode of this framebuffer (render target + depth/stencil).
++     * Per-framebuffer so a custom FBO can differ from the window: e.g. the mpv
++     * video FBO uses SCE_GXM_MULTISAMPLE_NONE (a fullscreen video quad gains
++     * nothing from MSAA) and saves the ~6 MB CDRAM a 4X depth/stencil surface
++     * costs at 960x544. SCE_GXM_MULTISAMPLE_NONE == 0, so a caller that leaves
++     * this zero-initialised gets no multisampling.
++     */
++    SceGxmMultisampleMode msaa;
+ };
+ typedef struct NVGXMframebufferInitOptions NVGXMframebufferInitOptions;
+ 
+@@ -561,6 +571,7 @@ NVGXMwindow *gxmCreateWindow(const NVGXMinitOptions *opts) {
+             .display_width = DISPLAY_WIDTH,
+             .display_height = DISPLAY_HEIGHT,
+             .display_stride = DISPLAY_STRIDE,
++            .msaa = opts->msaa,  // window keeps the app-requested MSAA (UI AA)
+     };
+     window->fb = gxmCreateFramebuffer(&framebufferOpts);
+     if (!window->fb) {
+@@ -790,11 +801,26 @@ NVGXMframebuffer *gxmCreateFramebuffer(const NVGXMframebufferInitOptions *opts)
+     render_target_params.width = opts->display_width;
+     render_target_params.height = opts->display_height;
+     render_target_params.scenesPerFrame = opts->scenesPerFrame;
+-    render_target_params.multisampleMode = gxm_internal.initOptions.msaa;
++    // Per-framebuffer MSAA (opts->msaa), not the global window mode, so a custom
++    // FBO (mpv video) can opt out of multisampling to save its depth/stencil.
++    render_target_params.multisampleMode = opts->msaa;
      render_target_params.multisampleLocations = 0;
      render_target_params.driverMemBlock = -1;
  
@@ -287,7 +319,30 @@ index 28a06ed6..f2345010 100644
  
      fb->gxm_color_surfaces = (NVGXMcolorSurface *) malloc(opts->display_buffer_count * sizeof(NVGXMcolorSurface));
      if (fb->gxm_color_surfaces == NULL) {
-@@ -882,7 +895,8 @@ void gxmDeleteFramebuffer(NVGXMframebuffer *fb) {
+@@ -824,7 +850,7 @@ NVGXMframebuffer *gxmCreateFramebuffer(const NVGXMframebufferInitOptions *opts)
+         sceGxmColorSurfaceInit(&fb->gxm_color_surfaces[i].surface,
+                                opts->color_format,
+                                opts->color_surface_type,
+-                               (gxm_internal.initOptions.msaa == SCE_GXM_MULTISAMPLE_NONE)
++                               (opts->msaa == SCE_GXM_MULTISAMPLE_NONE)
+                                ? SCE_GXM_COLOR_SURFACE_SCALE_NONE
+                                : SCE_GXM_COLOR_SURFACE_SCALE_MSAA_DOWNSCALE,
+                                SCE_GXM_OUTPUT_REGISTER_SIZE_32BIT,
+@@ -839,11 +865,11 @@ NVGXMframebuffer *gxmCreateFramebuffer(const NVGXMframebufferInitOptions *opts)
+     unsigned int depth_stencil_height = ALIGN(opts->display_height, SCE_GXM_TILE_SIZEY);
+     unsigned int depth_stencil_samples = depth_stencil_width * depth_stencil_height;
+ 
+-    if (gxm_internal.initOptions.msaa == SCE_GXM_MULTISAMPLE_4X) {
++    if (opts->msaa == SCE_GXM_MULTISAMPLE_4X) {
+         // samples increase in X and Y
+         depth_stencil_samples *= 4;
+         depth_stencil_width *= 2;
+-    } else if (gxm_internal.initOptions.msaa == SCE_GXM_MULTISAMPLE_2X) {
++    } else if (opts->msaa == SCE_GXM_MULTISAMPLE_2X) {
+         // samples increase in Y only
+         depth_stencil_samples *= 2;
+     }
+@@ -882,7 +908,8 @@ void gxmDeleteFramebuffer(NVGXMframebuffer *fb) {
          free(fb->gxm_color_surfaces);
      }
  


### PR DESCRIPTION
## Problème

Le contexte GXM tourne en MSAA 4× et `gxmCreateFramebuffer` dimensionnait la depth/stencil surface de **chaque** framebuffer à partir du mode **global** unique. Le FBO vidéo mpv héritait donc d'une depth/stencil 4× — **~8 Mo de CDRAM** en 960×544 (`4 * 960*544 * 4 samples`, aligné 256 Ko) — pour un **quad vidéo plein écran**, qui n'a aucune arête géométrique à antialiaser. Gaspillage pur, et il tombe **pendant la lecture**, quand la mémoire GPU est la plus tendue (surfaces de décodage vidéo + artwork + FBO) : l'allocation du FBO mpv est déjà la première à échouer sous pression (d'où le garde de #58 qui désactive la sortie vidéo au lieu de fauter).

Point clé : les **color surfaces** utilisent `SCE_GXM_COLOR_SURFACE_SCALE_MSAA_DOWNSCALE` → elles restent en résolution d'affichage, **non** multipliées par le MSAA. Seule la depth/stencil grossit.

### Mesures (test C++ autonome, formule de `gxmCreateFramebuffer`)

Depth/stencil 960×544 : **4× = 8,0 Mo · 2× = 4,0 Mo · NONE = 2,0 Mo**.
Pendant la lecture, la fenêtre **et** le FBO mpv détenaient chacun une surface 4× de 8 Mo (16 Mo de depth/stencil).

## Correctif

Donner à chaque framebuffer son propre MSAA au lieu du mode global :

- **borealis** (`scripts/patches/borealis-fixes.patch`) : `NVGXMframebufferInitOptions` gagne un champ `msaa` ; `gxmCreateFramebuffer` dimensionne le render target, l'échelle de color surface et la depth/stencil depuis `opts->msaa` ; `gxmCreateWindow` passe le mode demandé par l'app → **la fenêtre UI garde son MSAA inchangé** (nanovg tourne avec `edgeAntiAlias` désactivé, donc cet AA est indispensable — non touché ici).
- **app** (`mpv_core.cpp`) : le FBO vidéo et les params de rendu GXM de mpv utilisent tous deux `SCE_GXM_MULTISAMPLE_NONE` (ils **doivent** correspondre). Sa depth/stencil passe de 8 → 2 Mo.

**Net : ~6 Mo de CDRAM libérés pendant la lecture, aucun changement visuel** (la vidéo est un raster déjà résolu ; l'UI garde son 4×). Les fragment programs de la fenêtre restent sur le mode global et ne rendent que dans la fenêtre → aucune incohérence de sample mode.

Bénéfice secondaire : le FBO mpv est plus petit → son allocation réussit plus souvent sous pression, réduisant les cas de « video output disabled ».

## Vérifications

- Cross-build Vita (Docker `vitasdk/vitasdk`, `-DPLATFORM_PSV=ON -DUSE_GXM=ON`) : **compile**.
- Patch régénéré : `git apply --check` **propre**.
- **Non vérifié sur matériel** (pas de Vita) : `SCE_GXM_MULTISAMPLE_NONE` est le mode de sample le plus simple et le backend GXM de mpv paramètre déjà sur `msaa` (il possède des fragment programs NONE), mais le rendu vidéo réel reste à confirmer par un testeur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
